### PR TITLE
Experimentation adding code from arm64

### DIFF
--- a/erts/emulator/beam/jit/arm/32/beam_asm_module.cpp
+++ b/erts/emulator/beam/jit/arm/32/beam_asm_module.cpp
@@ -158,6 +158,12 @@ void BeamModuleAssembler::emit_i_func_info(const ArgWord &Label,
                                            const ArgAtom &Module,
                                            const ArgAtom &Function,
                                            const ArgWord &Arity) {
+
+    /* `op_i_func_info_IaaI` is used in various places in the emulator, so this
+     * label is always encoded as a word, even though the signature ought to
+     * be `op_i_func_info_LaaI`. */
+    functions.push_back(Label.get());
+
     // TODO
 }
 

--- a/erts/emulator/beam/jit/arm/32/beam_asm_module.cpp
+++ b/erts/emulator/beam/jit/arm/32/beam_asm_module.cpp
@@ -158,42 +158,7 @@ void BeamModuleAssembler::emit_i_func_info(const ArgWord &Label,
                                            const ArgAtom &Module,
                                            const ArgAtom &Function,
                                            const ArgWord &Arity) {
-    ErtsCodeInfo info = {};
-
-    /* `op_i_func_info_IaaI` is used in various places in the emulator, so this
-     * label is always encoded as a word, even though the signature ought to
-     * be `op_i_func_info_LaaI`. */
-    functions.push_back(Label.get());
-
-    info.mfa.module = Module.get();
-    info.mfa.function = Function.get();
-    info.mfa.arity = Arity.get();
-
-    comment("%T:%T/%d", info.mfa.module, info.mfa.function, info.mfa.arity);
-
-    /* This is an ErtsCodeInfo structure that has a valid ARM opcode as its `op`
-     * field, which *calls* the `raise_function_clause` fragment so we can trace
-     * it back to this particular function.
-     *
-     * We also use this field to store the current breakpoint flag, as ARM is a
-     * bit more strict about modifying code than x86: only branch instructions
-     * can be safely modified without issuing an ISB. By storing the flag here
-     * and reading it in the fragment, we don't have to change any code other
-     * than the branch instruction. */
-    if (code_header.isValid()) {
-        /* We avoid using the `fragment_call` helper to ensure a constant
-         * layout, as it adds code in certain debug configurations. */
-        a.bl(resolve_fragment(ga->get_i_func_info_shared(), disp128MB));
-    } else {
-        a.udf(0xF1F0);
-    }
-
-    ERTS_CT_ASSERT(ERTS_ASM_BP_FLAG_NONE == 0);
-    a.embedUInt32(0);
-
-    ASSERT(a.offset() % sizeof(UWord) == 0);
-    a.embed(&info.gen_bp, sizeof(info.gen_bp));
-    a.embed(&info.mfa, sizeof(info.mfa));
+    // TODO
 }
 
 void BeamModuleAssembler::emit_label(const ArgLabel &Label) {

--- a/erts/emulator/beam/jit/arm/32/beam_asm_module.cpp
+++ b/erts/emulator/beam/jit/arm/32/beam_asm_module.cpp
@@ -158,13 +158,42 @@ void BeamModuleAssembler::emit_i_func_info(const ArgWord &Label,
                                            const ArgAtom &Module,
                                            const ArgAtom &Function,
                                            const ArgWord &Arity) {
+    ErtsCodeInfo info = {};
 
     /* `op_i_func_info_IaaI` is used in various places in the emulator, so this
      * label is always encoded as a word, even though the signature ought to
      * be `op_i_func_info_LaaI`. */
     functions.push_back(Label.get());
 
-    // TODO
+    info.mfa.module = Module.get();
+    info.mfa.function = Function.get();
+    info.mfa.arity = Arity.get();
+
+    comment("%T:%T/%d", info.mfa.module, info.mfa.function, info.mfa.arity);
+
+    /* This is an ErtsCodeInfo structure that has a valid ARM opcode as its `op`
+     * field, which *calls* the `raise_function_clause` fragment so we can trace
+     * it back to this particular function.
+     *
+     * We also use this field to store the current breakpoint flag, as ARM is a
+     * bit more strict about modifying code than x86: only branch instructions
+     * can be safely modified without issuing an ISB. By storing the flag here
+     * and reading it in the fragment, we don't have to change any code other
+     * than the branch instruction. */
+    if (code_header.isValid()) {
+        /* We avoid using the `fragment_call` helper to ensure a constant
+         * layout, as it adds code in certain debug configurations. */
+        a.bl(resolve_fragment(ga->get_i_func_info_shared(), disp128MB));
+    } else {
+        a.udf(0xF1F0);
+    }
+
+    ERTS_CT_ASSERT(ERTS_ASM_BP_FLAG_NONE == 0);
+    a.embedUInt32(0);
+
+    ASSERT(a.offset() % sizeof(UWord) == 0);
+    a.embed(&info.gen_bp, sizeof(info.gen_bp));
+    a.embed(&info.mfa, sizeof(info.mfa));
 }
 
 void BeamModuleAssembler::emit_label(const ArgLabel &Label) {


### PR DESCRIPTION
This leads to a new crash in `BeamModuleAssembler::register_metadata` -> erts_codeinfo_to_code line 391 in beam_jit_common.cpp
Specifically, the assertion ASSERT_MFA fails

`beam/code_ix.h:304:erts_codeinfo_to_code() Assertion failed: ((((&ci->mfa)->module) & 0x3F) == ((0x0 << 4) | ((0x2 << 2) | 0x3))) && ((((&ci->mfa)->function) & 0x3F) == ((0x0 << 4) | ((0x2 << 2) | 0x3)))
`

The assert fails because the `ErtsCodeInfo` structure is empty. (No surprise here)
`mfa = {module = 0, function = 0, arity = 0}` 

