### PR TITLE
Put ASSERT(false); in every TODO section of unimplemented functions

### DIFF
--- a/erts/emulator/beam/jit/arm/32/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/32/beam_asm.hpp
@@ -175,6 +175,7 @@ protected:
     arm::Mem emit_setup_dispatchable_call(const a32::Gp &Src,
                                           const a32::Gp &CodeIndex) {
         // TODO
+        ASSERT(false);
         arm::Mem m;
         return m;
     }
@@ -205,18 +206,22 @@ protected:
 
     void emit_enter_erlang_frame() {
         // TODO
+        ASSERT(false);
     }
 
     void emit_leave_erlang_frame() {
         // TODO
+        ASSERT(false);
     }
 
     void emit_enter_runtime_frame() {
         // TODO
+        ASSERT(false);
     }
 
     void emit_leave_runtime_frame() {
         // TODO
+        ASSERT(false);
     }
 
     /* We keep the first six X registers in machine registers. Some of those
@@ -234,37 +239,45 @@ protected:
     template<int Spec = 0>
     void emit_enter_runtime(int live = num_register_backed_xregs) {
         // TODO
+        ASSERT(false);
     }
 
     template<int Spec = 0>
     void emit_leave_runtime(int live = num_register_backed_xregs) {
         // TODO
+        ASSERT(false);
     }
 
     void emit_is_cons(Label Fail, a32::Gp Src) {
         // TODO
+        ASSERT(false);
     }
 
     void emit_is_not_cons(Label Fail, a32::Gp Src) {
         // TODO
+        ASSERT(false);
     }
 
     void emit_is_boxed(Label Fail, a32::Gp Src) {
         // TODO
+        ASSERT(false);
     }
 
     void emit_is_not_boxed(Label Fail, a32::Gp Src) {
         // TODO
+        ASSERT(false);
     }
 
     a32::Gp emit_ptr_val(a32::Gp Dst, a32::Gp Src) {
         a32::Gp r;
         // TODO
+        ASSERT(false);
         return r;
     }
 
     void emit_untag_ptr(a32::Gp Dst, a32::Gp Src) {
         // TODO
+        ASSERT(false);
     }
 
     constexpr arm::Mem emit_boxed_val(a32::Gp Src, int32_t bytes = 0) const {
@@ -274,18 +287,22 @@ protected:
 
     void emit_branch_if_not_value(a32::Gp reg, Label lbl) {
         // TODO
+        ASSERT(false);
     }
 
     void emit_branch_if_value(a32::Gp reg, Label lbl) {
         // TODO
+        ASSERT(false);
     }
 
     void emit_branch_if_eq(a32::Gp reg, Uint value, Label lbl) {
         // TODO
+        ASSERT(false);
     }
 
     void emit_branch_if_ne(a32::Gp reg, Uint value, Label lbl) {
         // TODO
+        ASSERT(false);
     }
 
     /* Set the Z flag if Reg1 and Reg2 are definitely not equal based
@@ -293,48 +310,59 @@ protected:
      * immediates and all other bits are equal too.) */
     void emit_is_unequal_based_on_tags(a32::Gp Reg1, a32::Gp Reg2) {
         // TODO
+        ASSERT(false);
     }
 
     a32::Gp follow_size(const a32::Gp &reg, const a32::Gp &size) {
         // TODO
+        ASSERT(false);
         return reg;
     }
 
     template<typename T>
     void mov_imm(a32::Gp to, T value) {
         // TODO
+        ASSERT(false);
     }
 
     void mov_imm(a32::Gp to, std::nullptr_t value) {
         // TODO
+        ASSERT(false);
     }
 
     void sub(a32::Gp to, a32::Gp src, int64_t val) {
         // TODO
+        ASSERT(false);
     }
 
     void add(a32::Gp to, a32::Gp src, int64_t val) {
         // TODO
+        ASSERT(false);
     }
 
     void subs(a32::Gp to, a32::Gp src, int64_t val) {
         // TODO
+        ASSERT(false);
     }
 
     void cmp(a32::Gp src, int64_t val) {
         // TODO
+        ASSERT(false);
     }
 
     void ldur(a32::Gp reg, arm::Mem mem) {
         // TODO
+        ASSERT(false);
     }
 
     void stur(a32::Gp reg, arm::Mem mem) {
         // TODO
+        ASSERT(false);
     }
 
     void safe_9bit_imm(uint32_t instId, a32::Gp reg, arm::Mem mem) {
         // TODO
+        ASSERT(false);
     }
 
     /*
@@ -344,6 +372,7 @@ protected:
      */
     void lea(a32::Gp to, arm::Mem mem) {
         // TODO
+        ASSERT(false);
     }
 };
 
@@ -484,47 +513,57 @@ class BeamModuleAssembler : public BeamAssembler,
 
     void reg_cache_put(arm::Mem mem, a32::Gp src) {
         // TODO
+        ASSERT(false);
     }
 
     a32::Gp find_cache(arm::Mem mem) {
         // TODO
+        ASSERT(false);
         return reg_cache.find(a.offset(), mem);
     }
 
     /* Works as the STR instruction, but also updates the cache. */
     void str_cache(a32::Gp src, arm::Mem mem_dst) {
         // TODO
+        ASSERT(false);
     }
 
     /* Works as the STP instruction, but also updates the cache. */
     void stp_cache(a32::Gp src1, a32::Gp src2, arm::Mem mem_dst) {
         // TODO
+        ASSERT(false);
     }
 
     /* Works like LDR, but looks in the cache first. */
     void ldr_cached(a32::Gp dst, arm::Mem mem) {
         // TODO
+        ASSERT(false);
     }
 
     template<typename L, typename... Any>
     void preserve_cache(L generate, Any... clobber) {
         // TODO
+        ASSERT(false);
     }
 
     void trim_preserve_cache(const ArgWord &Words) {
         // TODO
+        ASSERT(false);
     }
 
     void mov_preserve_cache(a32::VecD dst, a32::VecD src) {
         // TODO
+        ASSERT(false);
     }
 
     void mov_preserve_cache(a32::Gp dst, a32::Gp src) {
         // TODO
+        ASSERT(false);
     }
 
     void untag_ptr_preserve_cache(a32::Gp dst, a32::Gp src) {
         // TODO
+        ASSERT(false);
     }
 
     arm::Mem embed_label(const Label &label, enum Displacement disp);
@@ -604,22 +643,27 @@ protected:
 
     void emit_is_cons(Label Fail, a32::Gp Src) {
         // TODO
+        ASSERT(false);
     }
 
     void emit_is_not_cons(Label Fail, a32::Gp Src) {
         // TODO
+        ASSERT(false);
     }
 
     void emit_is_list(Label Fail, a32::Gp Src) {
         // TODO
+        ASSERT(false);
     }
 
     void emit_is_boxed(Label Fail, a32::Gp Src) {
         // TODO
+        ASSERT(false);
     }
 
     void emit_is_boxed(Label Fail, const ArgVal &Arg, a32::Gp Src) {
         // TODO
+        ASSERT(false);
     }
 
     /* Copies `count` words from the address at `from`, to the address at `to`.
@@ -858,6 +902,7 @@ protected:
 
     bool isRegisterBacked(const ArgVal &arg) {
         // TODO
+        ASSERT(false);
         return false;
     }
 
@@ -874,16 +919,19 @@ protected:
 
     Variable<a32::Gp> init_destination(const ArgVal &arg, a32::Gp tmp) {
         // TODO
+        ASSERT(false);
         return Variable(tmp);
     }
 
     Variable<a32::VecD> init_destination(const ArgVal &arg, a32::VecD tmp) {
         // TODO
+        ASSERT(false);
         return Variable(tmp);
     }
 
     Variable<a32::Gp> load_source(const ArgVal &arg, a32::Gp tmp) {
         // TODO
+        ASSERT(false);
         return Variable(tmp);
     }
 
@@ -911,7 +959,9 @@ protected:
     Variable<a32::Gp> load_source(const ArgVal &arg) {
         a32::Gp todo;
         // TODO
+        ASSERT(false);
         return Variable(todo); // TODO
+        ASSERT(false);
     }
 
     auto load_sources(const ArgVal &Src1,
@@ -938,6 +988,7 @@ protected:
 
     Variable<a32::VecD> load_source(const ArgVal &arg, a32::VecD tmp) {
         // TODO
+        ASSERT(false);
         return Variable<a32::VecD>(tmp);
     }
 
@@ -953,24 +1004,29 @@ protected:
     template<typename Reg>
     void mov_var(const Variable<Reg> &to, const Variable<Reg> &from) {
         // TODO
+        ASSERT(false);
     }
 
     template<typename Reg>
     void mov_var(const Variable<Reg> &to, Reg from) {
         // TODO
+        ASSERT(false);
     }
 
     template<typename Reg>
     void mov_var(Reg to, const Variable<Reg> &from) {
         // TODO
+        ASSERT(false);
     }
 
     void flush_var(const Variable<a32::Gp> &to) {
         // TODO
+        ASSERT(false);
     }
 
     void flush_var(const Variable<a32::VecD> &to) {
         // TODO
+        ASSERT(false);
     }
 
     enum Relation { none, consecutive, reverse_consecutive };
@@ -978,46 +1034,56 @@ protected:
     static Relation memory_relation(const arm::Mem &mem1,
                                     const arm::Mem &mem2) {
         // TODO
+        ASSERT(false);
         return none;
     }
 
     void flush_vars(const Variable<a32::Gp> &to1,
                     const Variable<a32::Gp> &to2) {
         // TODO
+        ASSERT(false);
     }
 
     void flush_vars(const Variable<a32::Gp> &to1,
                     const Variable<a32::Gp> &to2,
                     const Variable<a32::Gp> &to3) {
         // TODO
+        ASSERT(false);
     }
 
     void mov_arg(const ArgRegister &To, const ArgVal &From) {
         // TODO
+        ASSERT(false);
     }
 
     void mov_arg(const ArgRegister &To, arm::Mem From) {
         // TODO
+        ASSERT(false);
     }
 
     void mov_arg(arm::Mem To, const ArgVal &From) {
         // TODO
+        ASSERT(false);
     }
 
     void mov_arg(a32::Gp to, const ArgVal &from) {
         // TODO
+        ASSERT(false);
     }
 
     void mov_arg(const ArgVal &to, a32::Gp from) {
         // TODO
+        ASSERT(false);
     }
 
     void cmp_arg(a32::Gp gp, const ArgVal &arg) {
         // TODO
+        ASSERT(false);
     }
 
     void safe_str(a32::Gp gp, arm::Mem mem) {
         // TODO
+        ASSERT(false);
     }
 
     void safe_stp(a32::Gp gp1,
@@ -1026,19 +1092,23 @@ protected:
                   const ArgVal &Dst1,
                   const ArgVal &Dst2) {
         // TODO
+        ASSERT(false);
     }
 
     void safe_stp(a32::Gp gp1, a32::Gp gp2, arm::Mem mem) {
         // TODO
+        ASSERT(false);
     }
 
     void safe_ldr(a32::Gp gp, arm::Mem mem) {
         // TODO
+        ASSERT(false);
     }
 
     void safe_ldur(a32::Gp gp, arm::Mem mem) {
 
         // TODO
+        ASSERT(false);
     }
 
     void safe_ldp(a32::Gp gp1,
@@ -1046,10 +1116,12 @@ protected:
                   const ArgVal &Src1,
                   const ArgVal &Src2) {
         // TODO
+        ASSERT(false);
     }
 
     void safe_ldp(a32::Gp gp1, a32::Gp gp2, arm::Mem mem) {
         // TODO
+        ASSERT(false);
     }
 
     /* Set the Z flag if Reg1 and Reg2 are definitely not equal based
@@ -1061,6 +1133,7 @@ protected:
                                        const ArgVal &Src2,
                                        a32::Gp Reg2) {
         // TODO
+        ASSERT(false);
 
     }
 
@@ -1070,6 +1143,7 @@ protected:
                                  const ArgVal &Src2,
                                  a32::Gp Reg2) {
         // TODO
+        ASSERT(false);
     }
 };
 

--- a/erts/emulator/beam/jit/arm/32/beam_asm_global.cpp
+++ b/erts/emulator/beam/jit/arm/32/beam_asm_global.cpp
@@ -95,6 +95,7 @@ BeamGlobalAssembler::BeamGlobalAssembler(JitAllocator *allocator)
  * ARG4 = Live registers */
 void BeamGlobalAssembler::emit_garbage_collect() {
     // TODO
+    ASSERT(false);
 }
 
 /* Handles trapping to exports from C code, setting registers up in the same
@@ -108,6 +109,7 @@ void BeamGlobalAssembler::emit_garbage_collect() {
  * Assumes that c_p->current points into the MFA of an export entry. */
 void BeamGlobalAssembler::emit_bif_export_trap() {
     // TODO
+    ASSERT(false);
 }
 
 /* Handles export breakpoints, error handler, jump tracing, and so on.
@@ -120,6 +122,7 @@ void BeamGlobalAssembler::emit_bif_export_trap() {
  */
 void BeamGlobalAssembler::emit_export_trampoline() {
     // TODO
+    ASSERT(false);
 }
 
 /*
@@ -128,41 +131,50 @@ void BeamGlobalAssembler::emit_export_trampoline() {
  */
 void BeamModuleAssembler::emit_raise_exception() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_raise_exception(const ErtsCodeMFA *exp) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_raise_exception(Label I,
                                                const ErtsCodeMFA *exp) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamGlobalAssembler::emit_process_exit() {
     // TODO
+    ASSERT(false);
 }
 
 /* You must have already done emit_leave_runtime_frame()! */
 void BeamGlobalAssembler::emit_raise_exception_null_exp() {
     // TODO
+    ASSERT(false);
 }
 
 /* You must have already done emit_leave_runtime_frame()! */
 void BeamGlobalAssembler::emit_raise_exception() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamGlobalAssembler::emit_raise_exception_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_proc_lc_unrequire(void) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_proc_lc_require(void) {
     // TODO
+    ASSERT(false);
 }
 
 extern "C"

--- a/erts/emulator/beam/jit/arm/32/beam_asm_module.cpp
+++ b/erts/emulator/beam/jit/arm/32/beam_asm_module.cpp
@@ -95,14 +95,17 @@ BeamModuleAssembler::BeamModuleAssembler(BeamGlobalAssembler *ga,
 
 void BeamModuleAssembler::emit_i_nif_padding() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamGlobalAssembler::emit_i_breakpoint_trampoline_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_breakpoint_trampoline() {
     // TODO
+    ASSERT(false);
 }
 
 static void i_emit_nyi(char *msg) {
@@ -111,6 +114,7 @@ static void i_emit_nyi(char *msg) {
 
 void BeamModuleAssembler::emit_nyi(const char *msg) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_nyi() {
@@ -152,6 +156,7 @@ bool BeamModuleAssembler::emit(unsigned specific_op, const Span<ArgVal> &args) {
 
 void BeamGlobalAssembler::emit_i_func_info_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_func_info(const ArgWord &Label,
@@ -213,6 +218,7 @@ void BeamModuleAssembler::emit_aligned_label(const ArgLabel &Label,
 
 void BeamModuleAssembler::emit_on_load() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::bind_veneer_target(const Label &target) {
@@ -275,6 +281,7 @@ void BeamModuleAssembler::emit_line(const ArgWord &Loc) {
      * Since line addresses are taken _after_ line instructions we can avoid
      * this by adding a nop when we detect this condition. */
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_func_line(const ArgWord &Loc) {
@@ -384,6 +391,7 @@ const Label &BeamModuleAssembler::resolve_fragment(void (*fragment)(),
 
 void BeamModuleAssembler::emit_i_flush_stubs() {
         // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::check_pending_stubs() {
@@ -458,8 +466,10 @@ void BeamModuleAssembler::flush_pending_stubs(size_t range) {
 
 void BeamModuleAssembler::emit_veneer(const Veneer &veneer) {
         // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_constant(const Constant &constant) {
         // TODO
+    ASSERT(false);
 }

--- a/erts/emulator/beam/jit/arm/32/beam_asm_module.cpp
+++ b/erts/emulator/beam/jit/arm/32/beam_asm_module.cpp
@@ -163,6 +163,8 @@ void BeamModuleAssembler::emit_i_func_info(const ArgWord &Label,
                                            const ArgAtom &Module,
                                            const ArgAtom &Function,
                                            const ArgWord &Arity) {
+    // TODO
+    ASSERT(false);
     ErtsCodeInfo info = {};
 
     /* `op_i_func_info_IaaI` is used in various places in the emulator, so this
@@ -202,6 +204,8 @@ void BeamModuleAssembler::emit_i_func_info(const ArgWord &Label,
 }
 
 void BeamModuleAssembler::emit_label(const ArgLabel &Label) {
+    // TODO
+    ASSERT(false);
     ASSERT(Label.isLabel());
 
     current_label = rawLabels[Label.get()];
@@ -212,6 +216,8 @@ void BeamModuleAssembler::emit_label(const ArgLabel &Label) {
 
 void BeamModuleAssembler::emit_aligned_label(const ArgLabel &Label,
                                              const ArgWord &Alignment) {
+    // TODO
+    ASSERT(false);
     a.align(AlignMode::kCode, Alignment.get());
     emit_label(Label);
 }
@@ -222,6 +228,8 @@ void BeamModuleAssembler::emit_on_load() {
 }
 
 void BeamModuleAssembler::bind_veneer_target(const Label &target) {
+    // TODO
+    ASSERT(false);
     auto veneer_range = _veneers.equal_range(target.id());
     for (auto it = veneer_range.first; it != veneer_range.second; it++) {
         const Veneer &veneer = it->second;
@@ -240,6 +248,8 @@ void BeamModuleAssembler::bind_veneer_target(const Label &target) {
 }
 
 void BeamModuleAssembler::emit_int_code_end() {
+    // TODO
+    ASSERT(false);
     /* This label is used to figure out the end of the last function */
     code_end = a.newLabel();
     a.bind(code_end);
@@ -318,6 +328,8 @@ void BeamModuleAssembler::emit_call_error_handler() {
 const Label &BeamModuleAssembler::resolve_label(const Label &target,
                                                 enum Displacement disp,
                                                 const char *labelName) {
+    // TODO
+    ASSERT(false);
     ssize_t currOffset = a.offset();
 
     ssize_t minOffset = currOffset - disp;
@@ -380,6 +392,8 @@ const Label &BeamModuleAssembler::resolve_label(const Label &target,
 
 const Label &BeamModuleAssembler::resolve_fragment(void (*fragment)(),
                                                    enum Displacement disp) {
+    // TODO
+    ASSERT(false);
     auto it = _dispatchTable.find(fragment);
 
     if (it == _dispatchTable.end()) {
@@ -395,6 +409,8 @@ void BeamModuleAssembler::emit_i_flush_stubs() {
 }
 
 void BeamModuleAssembler::check_pending_stubs() {
+    // TODO
+    ASSERT(false);
     size_t currOffset = a.offset();
 
     /* We shouldn't let too much space pass between checks. */
@@ -408,6 +424,8 @@ void BeamModuleAssembler::check_pending_stubs() {
 }
 
 void BeamModuleAssembler::flush_pending_stubs(size_t range) {
+    // TODO
+    ASSERT(false);
     ssize_t effective_offset = a.offset() + range;
     Label next;
 

--- a/erts/emulator/beam/jit/arm/32/instr_arith.cpp
+++ b/erts/emulator/beam/jit/arm/32/instr_arith.cpp
@@ -33,6 +33,7 @@ void BeamModuleAssembler::emit_add_sub_types(bool is_small_result,
                                              const a32::Gp rhs_reg,
                                              const Label next) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_are_both_small(const ArgSource &LHS,
@@ -41,6 +42,7 @@ void BeamModuleAssembler::emit_are_both_small(const ArgSource &LHS,
                                               const a32::Gp rhs_reg,
                                               const Label next) {
     // TODO
+    ASSERT(false);
 }
 
 /*
@@ -54,6 +56,7 @@ void BeamModuleAssembler::emit_are_both_small(const ArgSource &LHS,
  */
 void BeamGlobalAssembler::emit_plus_body_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_plus(const ArgLabel &Fail,
@@ -62,6 +65,7 @@ void BeamModuleAssembler::emit_i_plus(const ArgLabel &Fail,
                                       const ArgSource &RHS,
                                       const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 /*
@@ -74,6 +78,7 @@ void BeamModuleAssembler::emit_i_plus(const ArgLabel &Fail,
  */
 void BeamGlobalAssembler::emit_unary_minus_body_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_unary_minus(const ArgLabel &Fail,
@@ -81,6 +86,7 @@ void BeamModuleAssembler::emit_i_unary_minus(const ArgLabel &Fail,
                                              const ArgSource &Src,
                                              const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 /*
@@ -94,6 +100,7 @@ void BeamModuleAssembler::emit_i_unary_minus(const ArgLabel &Fail,
  */
 void BeamGlobalAssembler::emit_minus_body_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_minus(const ArgLabel &Fail,
@@ -102,6 +109,7 @@ void BeamModuleAssembler::emit_i_minus(const ArgLabel &Fail,
                                        const ArgSource &RHS,
                                        const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 /*
@@ -115,6 +123,7 @@ void BeamModuleAssembler::emit_i_minus(const ArgLabel &Fail,
  */
 void BeamGlobalAssembler::emit_int128_to_big_shared() {
     // TODO
+    ASSERT(false);
 }
 
 /* ARG2 = Src1
@@ -125,6 +134,7 @@ void BeamGlobalAssembler::emit_int128_to_big_shared() {
  */
 void BeamGlobalAssembler::emit_mul_add_body_shared() {
     // TODO
+    ASSERT(false);
 }
 
 /* ARG2 = Src1
@@ -136,6 +146,7 @@ void BeamGlobalAssembler::emit_mul_add_body_shared() {
  */
 void BeamGlobalAssembler::emit_mul_add_guard_shared() {
     // TODO
+    ASSERT(false);
 }
 
 /* ARG2 = Src1
@@ -145,6 +156,7 @@ void BeamGlobalAssembler::emit_mul_add_guard_shared() {
  */
 void BeamGlobalAssembler::emit_mul_body_shared() {
     // TODO
+    ASSERT(false);
 }
 
 /* ARG2 = Src1
@@ -155,6 +167,7 @@ void BeamGlobalAssembler::emit_mul_body_shared() {
  */
 void BeamGlobalAssembler::emit_mul_guard_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_mul_add(const ArgLabel &Fail,
@@ -164,6 +177,7 @@ void BeamModuleAssembler::emit_i_mul_add(const ArgLabel &Fail,
                                          const ArgSource &Src4,
                                          const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 /*
@@ -175,6 +189,7 @@ void BeamModuleAssembler::emit_i_mul_add(const ArgLabel &Fail,
  */
 void BeamGlobalAssembler::emit_int_div_rem_guard_shared() {
     // TODO
+    ASSERT(false);
 }
 
 /* ARG2 = LHS
@@ -195,6 +210,7 @@ void BeamModuleAssembler::emit_div_rem_literal(Sint divisor,
                                                bool need_div,
                                                bool need_rem) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_div_rem(const ArgLabel &Fail,
@@ -206,6 +222,7 @@ void BeamModuleAssembler::emit_div_rem(const ArgLabel &Fail,
                                        bool need_div,
                                        bool need_rem) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_rem_div(const ArgLabel &Fail,
@@ -215,6 +232,7 @@ void BeamModuleAssembler::emit_i_rem_div(const ArgLabel &Fail,
                                          const ArgRegister &Remainder,
                                          const ArgRegister &Quotient) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_div_rem(const ArgLabel &Fail,
@@ -224,6 +242,7 @@ void BeamModuleAssembler::emit_i_div_rem(const ArgLabel &Fail,
                                          const ArgRegister &Quotient,
                                          const ArgRegister &Remainder) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_int_div(const ArgLabel &Fail,
@@ -232,6 +251,7 @@ void BeamModuleAssembler::emit_i_int_div(const ArgLabel &Fail,
                                          const ArgSource &RHS,
                                          const ArgRegister &Quotient) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_rem(const ArgLabel &Fail,
@@ -240,6 +260,7 @@ void BeamModuleAssembler::emit_i_rem(const ArgLabel &Fail,
                                      const ArgSource &RHS,
                                      const ArgRegister &Remainder) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_m_div(const ArgLabel &Fail,
@@ -248,6 +269,7 @@ void BeamModuleAssembler::emit_i_m_div(const ArgLabel &Fail,
                                        const ArgSource &RHS,
                                        const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 /*
@@ -263,10 +285,12 @@ template<typename T>
 void BeamGlobalAssembler::emit_bitwise_fallback_body(T(*func_ptr),
                                                      const ErtsCodeMFA *mfa) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamGlobalAssembler::emit_i_band_body_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_band(const ArgLabel &Fail,
@@ -275,6 +299,7 @@ void BeamModuleAssembler::emit_i_band(const ArgLabel &Fail,
                                       const ArgSource &RHS,
                                       const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 /*
@@ -288,6 +313,7 @@ void BeamModuleAssembler::emit_i_band(const ArgLabel &Fail,
  */
 void BeamGlobalAssembler::emit_i_bor_body_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_bor(const ArgLabel &Fail,
@@ -296,6 +322,7 @@ void BeamModuleAssembler::emit_i_bor(const ArgLabel &Fail,
                                      const ArgSource &RHS,
                                      const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 /*
@@ -309,6 +336,7 @@ void BeamModuleAssembler::emit_i_bor(const ArgLabel &Fail,
  */
 void BeamGlobalAssembler::emit_i_bxor_body_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_bxor(const ArgLabel &Fail,
@@ -317,6 +345,7 @@ void BeamModuleAssembler::emit_i_bxor(const ArgLabel &Fail,
                                       const ArgSource &RHS,
                                       const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 /*
@@ -330,6 +359,7 @@ void BeamModuleAssembler::emit_i_bxor(const ArgLabel &Fail,
  */
 void BeamGlobalAssembler::emit_i_bnot_guard_shared() {
     // TODO
+    ASSERT(false);
 }
 
 /*
@@ -342,6 +372,7 @@ void BeamGlobalAssembler::emit_i_bnot_guard_shared() {
  */
 void BeamGlobalAssembler::emit_i_bnot_body_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_bnot(const ArgLabel &Fail,
@@ -349,6 +380,7 @@ void BeamModuleAssembler::emit_i_bnot(const ArgLabel &Fail,
                                       const ArgSource &Src,
                                       const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 /*
@@ -371,6 +403,7 @@ void BeamModuleAssembler::emit_i_bsr(const ArgLabel &Fail,
                                      const ArgSource &RHS,
                                      const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 /*
@@ -384,6 +417,7 @@ void BeamModuleAssembler::emit_i_bsr(const ArgLabel &Fail,
  */
 void BeamGlobalAssembler::emit_i_bsl_body_shared() {
     // TODO
+    ASSERT(false);
 }
 
 static int count_leading_zeroes(UWord value) {
@@ -402,4 +436,5 @@ void BeamModuleAssembler::emit_i_bsl(const ArgLabel &Fail,
                                      const ArgSource &RHS,
                                      const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }

--- a/erts/emulator/beam/jit/arm/32/instr_bif.cpp
+++ b/erts/emulator/beam/jit/arm/32/instr_bif.cpp
@@ -32,6 +32,7 @@ extern "C"
 
 void BeamModuleAssembler::ubif_comment(const ArgWord &Bif) {
     // TODO
+    ASSERT(false);
 }
 
 /* ARG2 = argument vector, ARG4 (!) = bif function pointer
@@ -39,6 +40,7 @@ void BeamModuleAssembler::ubif_comment(const ArgWord &Bif) {
  * Result is returned in ARG1 (will be THE_NON_VALUE if the BIF call failed). */
 void BeamGlobalAssembler::emit_i_bif_guard_shared() {
     // TODO
+    ASSERT(false);
 }
 
 /* ARG2 = argument vector, ARG4 (!) = bif function pointer
@@ -46,6 +48,7 @@ void BeamGlobalAssembler::emit_i_bif_guard_shared() {
  * Result is returned in RET. */
 void BeamGlobalAssembler::emit_i_bif_body_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_bif1(const ArgSource &Src1,
@@ -53,6 +56,7 @@ void BeamModuleAssembler::emit_i_bif1(const ArgSource &Src1,
                                       const ArgWord &Bif,
                                       const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_bif2(const ArgSource &Src1,
@@ -61,6 +65,7 @@ void BeamModuleAssembler::emit_i_bif2(const ArgSource &Src1,
                                       const ArgWord &Bif,
                                       const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_bif3(const ArgSource &Src1,
@@ -70,12 +75,14 @@ void BeamModuleAssembler::emit_i_bif3(const ArgSource &Src1,
                                       const ArgWord &Bif,
                                       const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_bif(const ArgLabel &Fail,
                                      const ArgWord &Bif,
                                      const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 /*
@@ -87,6 +94,7 @@ void BeamModuleAssembler::emit_nofail_bif1(const ArgSource &Src1,
                                            const ArgWord &Bif,
                                            const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_nofail_bif2(const ArgSource &Src1,
@@ -94,12 +102,14 @@ void BeamModuleAssembler::emit_nofail_bif2(const ArgSource &Src1,
                                            const ArgWord &Bif,
                                            const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_length_setup(const ArgLabel &Fail,
                                               const ArgWord &Live,
                                               const ArgSource &Src) {
     // TODO
+    ASSERT(false);
 }
 
 /* ARG2 = live registers, ARG3 = entry address
@@ -107,6 +117,7 @@ void BeamModuleAssembler::emit_i_length_setup(const ArgLabel &Fail,
  * Result is returned in RET. */
 void BeamGlobalAssembler::emit_i_length_common(Label fail, int state_size) {
     // TODO
+    ASSERT(false);
 }
 
 /* ARG2 = live registers, ARG3 = entry address
@@ -114,6 +125,7 @@ void BeamGlobalAssembler::emit_i_length_common(Label fail, int state_size) {
  * Result is returned in RET. */
 void BeamGlobalAssembler::emit_i_length_body_shared() {
     // TODO
+    ASSERT(false);
 }
 
 /* ARG2 = live registers, ARG3 = entry address
@@ -121,12 +133,14 @@ void BeamGlobalAssembler::emit_i_length_body_shared() {
  * Result is returned in ARG. Error is indicated by THE_NON_VALUE. */
 void BeamGlobalAssembler::emit_i_length_guard_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_length(const ArgLabel &Fail,
                                         const ArgWord &Live,
                                         const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 #if defined(DEBUG) || defined(ERTS_ENABLE_LOCK_CHECK)
@@ -137,6 +151,7 @@ static Eterm debug_call_light_bif(Process *c_p,
                                   ErtsBifFunc vbf) {
     Eterm result;
     // TODO
+    ASSERT(false);
     return result;
 }
 #endif
@@ -151,23 +166,28 @@ static Eterm debug_call_light_bif(Process *c_p,
  */
 void BeamGlobalAssembler::emit_call_light_bif_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_call_light_bif(const ArgWord &Bif,
                                               const ArgExport &Exp) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_send() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_nif_start() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamGlobalAssembler::emit_bif_nif_epilogue(void) {
     // TODO
+    ASSERT(false);
 }
 
 /* Used by call_bif, dispatch_bif, and export_trampoline.
@@ -181,26 +201,31 @@ void BeamGlobalAssembler::emit_bif_nif_epilogue(void) {
  * ARG4 = function to be called */
 void BeamGlobalAssembler::emit_call_bif_shared(void) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamGlobalAssembler::emit_dispatch_bif(void) {
     // TODO
+    ASSERT(false);
 }
 
 /* This is only used for opcode compatibility with the interpreter, it's never
  * actually called. */
 void BeamModuleAssembler::emit_call_bif(const ArgWord &Func) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_call_bif_mfa(const ArgAtom &M,
                                             const ArgAtom &F,
                                             const ArgWord &A) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamGlobalAssembler::emit_call_nif_early() {
     // TODO
+    ASSERT(false);
 }
 
 /* Used by call_nif, call_nif_early, and dispatch_nif.
@@ -212,14 +237,17 @@ void BeamGlobalAssembler::emit_call_nif_early() {
  * ARG3 = current I, just past the end of an ErtsCodeInfo. */
 void BeamGlobalAssembler::emit_call_nif_shared(void) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamGlobalAssembler::emit_dispatch_nif(void) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamGlobalAssembler::emit_call_nif_yield_helper() {
     // TODO
+    ASSERT(false);
 }
 
 /* WARNING: This stub is memcpy'd, so all code herein must be explicitly
@@ -228,10 +256,12 @@ void BeamModuleAssembler::emit_call_nif(const ArgWord &Func,
                                         const ArgWord &NifMod,
                                         const ArgWord &DirtyFunc) {
     // TODO
+    ASSERT(false);
 }
 
 static ErtsCodePtr get_on_load_address(Process *c_p, Eterm module) {
     // TODO
+    ASSERT(false);
     return NULL;
 }
 
@@ -239,8 +269,10 @@ static ErtsCodePtr get_on_load_address(Process *c_p, Eterm module) {
  * which is very tricky to implement as a BIF. */
 void BeamModuleAssembler::emit_i_call_on_load_function() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_load_nif() {
     // TODO
+    ASSERT(false);
 }

--- a/erts/emulator/beam/jit/arm/32/instr_bs.cpp
+++ b/erts/emulator/beam/jit/arm/32/instr_bs.cpp
@@ -37,6 +37,7 @@ int BeamModuleAssembler::emit_bs_get_field_size(const ArgSource &Size,
                                                 Label fail,
                                                 const a32::Gp &out) {
     // TODO
+    ASSERT(false);
     return -1;
 }
 
@@ -45,11 +46,13 @@ void BeamModuleAssembler::emit_i_bs_init_heap(const ArgWord &Size,
                                               const ArgWord &Live,
                                               const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 /* Set the error reason when a size check has failed. */
 void BeamGlobalAssembler::emit_bs_size_check_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_bs_init_fail_heap(const ArgSource &Size,
@@ -58,12 +61,14 @@ void BeamModuleAssembler::emit_i_bs_init_fail_heap(const ArgSource &Size,
                                                    const ArgWord &Live,
                                                    const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_bs_init(const ArgWord &Size,
                                          const ArgWord &Live,
                                          const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_bs_init_fail(const ArgRegister &Size,
@@ -71,12 +76,14 @@ void BeamModuleAssembler::emit_i_bs_init_fail(const ArgRegister &Size,
                                               const ArgWord &Live,
                                               const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_bs_init_bits(const ArgWord &NumBits,
                                               const ArgWord &Live,
                                               const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_bs_init_bits_heap(const ArgWord &NumBits,
@@ -84,6 +91,7 @@ void BeamModuleAssembler::emit_i_bs_init_bits_heap(const ArgWord &NumBits,
                                                    const ArgWord &Live,
                                                    const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_bs_init_bits_fail(const ArgRegister &NumBits,
@@ -91,6 +99,7 @@ void BeamModuleAssembler::emit_i_bs_init_bits_fail(const ArgRegister &NumBits,
                                                    const ArgWord &Live,
                                                    const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_bs_init_bits_fail_heap(
@@ -100,11 +109,13 @@ void BeamModuleAssembler::emit_i_bs_init_bits_fail_heap(
         const ArgWord &Live,
         const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_bs_put_string(const ArgWord &Size,
                                              const ArgBytePtr &Ptr) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_new_bs_put_integer_imm(const ArgSource &Src,
@@ -112,6 +123,7 @@ void BeamModuleAssembler::emit_i_new_bs_put_integer_imm(const ArgSource &Src,
                                                         const ArgWord &Sz,
                                                         const ArgWord &Flags) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_new_bs_put_integer(const ArgLabel &Fail,
@@ -119,6 +131,7 @@ void BeamModuleAssembler::emit_i_new_bs_put_integer(const ArgLabel &Fail,
                                                     const ArgWord &Flags,
                                                     const ArgSource &Src) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_new_bs_put_binary(const ArgLabel &Fail,
@@ -126,18 +139,21 @@ void BeamModuleAssembler::emit_i_new_bs_put_binary(const ArgLabel &Fail,
                                                    const ArgWord &Flags,
                                                    const ArgSource &Src) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_new_bs_put_binary_all(const ArgSource &Src,
                                                        const ArgLabel &Fail,
                                                        const ArgWord &Unit) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_new_bs_put_binary_imm(const ArgLabel &Fail,
                                                        const ArgWord &Sz,
                                                        const ArgSource &Src) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_new_bs_put_float(const ArgLabel &Fail,
@@ -145,6 +161,7 @@ void BeamModuleAssembler::emit_i_new_bs_put_float(const ArgLabel &Fail,
                                                   const ArgWord &Flags,
                                                   const ArgSource &Src) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_new_bs_put_float_imm(const ArgLabel &Fail,
@@ -152,6 +169,7 @@ void BeamModuleAssembler::emit_i_new_bs_put_float_imm(const ArgLabel &Fail,
                                                       const ArgWord &Flags,
                                                       const ArgSource &Src) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_bs_start_match3(const ArgRegister &Src,
@@ -159,6 +177,7 @@ void BeamModuleAssembler::emit_i_bs_start_match3(const ArgRegister &Src,
                                                  const ArgLabel &Fail,
                                                  const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_bs_match_string(const ArgRegister &Ctx,
@@ -166,12 +185,14 @@ void BeamModuleAssembler::emit_i_bs_match_string(const ArgRegister &Ctx,
                                                  const ArgWord &Bits,
                                                  const ArgBytePtr &Ptr) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_bs_get_position(const ArgRegister &Ctx,
                                                const ArgRegister &Dst,
                                                const ArgWord &Live) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_bs_get_integer2(const ArgLabel &Fail,
@@ -182,17 +203,20 @@ void BeamModuleAssembler::emit_bs_get_integer2(const ArgLabel &Fail,
                                                const ArgWord &Flags,
                                                const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_bs_test_tail2(const ArgLabel &Fail,
                                              const ArgRegister &Ctx,
                                              const ArgWord &Offset) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_bs_set_position(const ArgRegister &Ctx,
                                                const ArgRegister &Pos) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_bs_get_binary_all2(const ArgRegister &Ctx,
@@ -201,22 +225,26 @@ void BeamModuleAssembler::emit_i_bs_get_binary_all2(const ArgRegister &Ctx,
                                                     const ArgWord &Unit,
                                                     const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamGlobalAssembler::emit_bs_get_tail_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_bs_get_tail(const ArgRegister &Ctx,
                                            const ArgRegister &Dst,
                                            const ArgWord &Live) {
     // TODO
+    ASSERT(false);
 }
 
 /* Bits to skip are passed in ARG1 */
 void BeamModuleAssembler::emit_bs_skip_bits(const ArgLabel &Fail,
                                             const ArgRegister &Ctx) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_bs_skip_bits2(const ArgRegister &Ctx,
@@ -224,12 +252,14 @@ void BeamModuleAssembler::emit_i_bs_skip_bits2(const ArgRegister &Ctx,
                                                const ArgLabel &Fail,
                                                const ArgWord &Unit) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_bs_skip_bits_imm2(const ArgLabel &Fail,
                                                    const ArgRegister &Ctx,
                                                    const ArgWord &Bits) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_bs_get_binary2(const ArgRegister &Ctx,
@@ -239,6 +269,7 @@ void BeamModuleAssembler::emit_i_bs_get_binary2(const ArgRegister &Ctx,
                                                 const ArgWord &Flags,
                                                 const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_bs_get_float2(const ArgRegister &Ctx,
@@ -248,16 +279,19 @@ void BeamModuleAssembler::emit_i_bs_get_float2(const ArgRegister &Ctx,
                                                const ArgWord &Flags,
                                                const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_bs_utf8_size(const ArgSource &Src,
                                               const ArgXRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_bs_put_utf8(const ArgLabel &Fail,
                                              const ArgSource &Src) {
     // TODO
+    ASSERT(false);
 }
 
 /*
@@ -271,6 +305,7 @@ void BeamModuleAssembler::emit_i_bs_put_utf8(const ArgLabel &Fail,
  */
 void BeamGlobalAssembler::emit_bs_get_utf8_short_shared() {
     // TODO
+    ASSERT(false);
 }
 
 /*
@@ -284,39 +319,46 @@ void BeamGlobalAssembler::emit_bs_get_utf8_short_shared() {
  */
 void BeamGlobalAssembler::emit_bs_get_utf8_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_bs_get_utf8(const ArgRegister &Ctx,
                                            const ArgLabel &Fail) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_bs_get_utf8(const ArgRegister &Ctx,
                                              const ArgLabel &Fail,
                                              const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_bs_skip_utf8(const ArgRegister &Ctx,
                                               const ArgLabel &Fail) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_bs_utf16_size(const ArgSource &Src,
                                                const ArgXRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_bs_put_utf16(const ArgLabel &Fail,
                                               const ArgWord &Flags,
                                               const ArgSource &Src) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_bs_get_utf16(const ArgRegister &Ctx,
                                             const ArgLabel &Fail,
                                             const ArgWord &Flags) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_bs_get_utf16(const ArgRegister &Ctx,
@@ -324,23 +366,27 @@ void BeamModuleAssembler::emit_i_bs_get_utf16(const ArgRegister &Ctx,
                                               const ArgWord &Flags,
                                               const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_bs_skip_utf16(const ArgRegister &Ctx,
                                                const ArgLabel &Fail,
                                                const ArgWord &Flags) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_validate_unicode(Label next,
                                                 Label fail,
                                                 a32::Gp value) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_bs_validate_unicode(const ArgLabel &Fail,
                                                      const ArgSource &Src) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_bs_validate_unicode_retract(
@@ -348,12 +394,14 @@ void BeamModuleAssembler::emit_i_bs_validate_unicode_retract(
         const ArgSource &Src,
         const ArgRegister &Ms) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_bs_test_unit(const ArgLabel &Fail,
                                             const ArgRegister &Ctx,
                                             const ArgWord &Unit) {
     // TODO
+    ASSERT(false);
 }
 
 /* ARG2 = current `Size`,
@@ -363,6 +411,7 @@ void BeamModuleAssembler::emit_bs_test_unit(const ArgLabel &Fail,
  * Error is indicated through cond_ne() */
 void BeamGlobalAssembler::emit_bs_add_guard_shared() {
     // TODO
+    ASSERT(false);
 }
 
 /* ARG2 = current `Size`,
@@ -370,6 +419,7 @@ void BeamGlobalAssembler::emit_bs_add_guard_shared() {
  * ARG4 = element `Unit` */
 void BeamGlobalAssembler::emit_bs_add_body_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_bs_add(const ArgLabel &Fail,
@@ -378,6 +428,7 @@ void BeamModuleAssembler::emit_bs_add(const ArgLabel &Fail,
                                       const ArgWord &Unit,
                                       const ArgXRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_bs_append(const ArgLabel &Fail,
@@ -388,6 +439,7 @@ void BeamModuleAssembler::emit_i_bs_append(const ArgLabel &Fail,
                                            const ArgSource &Bin,
                                            const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_bs_private_append(const ArgLabel &Fail,
@@ -396,14 +448,17 @@ void BeamModuleAssembler::emit_i_bs_private_append(const ArgLabel &Fail,
                                                    const ArgRegister &Src,
                                                    const ArgXRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_bs_init_writable() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamGlobalAssembler::emit_bs_create_bin_error_shared() {
     // TODO
+    ASSERT(false);
 }
 
 /*
@@ -411,6 +466,7 @@ void BeamGlobalAssembler::emit_bs_create_bin_error_shared() {
  */
 void BeamGlobalAssembler::emit_get_sint64_shared() {
     // TODO
+    ASSERT(false);
 }
 
 struct BscSegment {
@@ -448,6 +504,7 @@ struct BscSegment {
 static std::vector<BscSegment> bs_combine_segments(
         const std::vector<BscSegment> segments) {
     // TODO
+    ASSERT(false);
     return std::vector<BscSegment>();
 }
 
@@ -472,6 +529,7 @@ void BeamModuleAssembler::update_bin_state(a32::Gp bin_offset,
                                            Sint size,
                                            a32::Gp size_reg) {
     // TODO
+    ASSERT(false);
 }
 
 /*
@@ -479,6 +537,7 @@ void BeamModuleAssembler::update_bin_state(a32::Gp bin_offset,
  */
 void BeamModuleAssembler::set_zero(Sint effectiveSize) {
     // TODO
+    ASSERT(false);
 }
 
 /*
@@ -495,12 +554,14 @@ void BeamModuleAssembler::set_zero(Sint effectiveSize) {
  */
 void BeamGlobalAssembler::emit_construct_utf8_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_construct_utf8(const ArgVal &Src,
                                               Sint bit_offset,
                                               bool is_byte_aligned) {
     // TODO
+    ASSERT(false);
 }
 
 /*
@@ -512,6 +573,7 @@ void BeamModuleAssembler::emit_construct_utf8(const ArgVal &Src,
  */
 void BeamGlobalAssembler::emit_store_unaligned() {
     // TODO
+    ASSERT(false);
 }
 
 /*
@@ -526,6 +588,7 @@ void BeamGlobalAssembler::emit_store_unaligned() {
 
 void BeamGlobalAssembler::emit_bs_init_bits_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
@@ -534,6 +597,7 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
                                                const ArgRegister &Dst,
                                                const Span<ArgVal> &args) {
     // TODO
+    ASSERT(false);
 }
 
 /*
@@ -571,6 +635,7 @@ void BeamModuleAssembler::emit_read_bits(Uint bits,
                                          const a32::Gp bin_offset,
                                          const a32::Gp bitdata) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_extract_integer(const a32::Gp &bitdata,
@@ -580,6 +645,7 @@ void BeamModuleAssembler::emit_extract_integer(const a32::Gp &bitdata,
                                                Uint bits,
                                                const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_extract_bitstring(const a32::Gp bitdata,
@@ -587,6 +653,7 @@ void BeamModuleAssembler::emit_extract_bitstring(const a32::Gp bitdata,
                                                  Uint bits,
                                                  const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 static std::vector<BsmSegment> opt_bsm_segments(
@@ -594,6 +661,7 @@ static std::vector<BsmSegment> opt_bsm_segments(
         const ArgWord &Need,
         const ArgWord &Live) {
     // TODO
+    ASSERT(false);
     return std::vector<BsmSegment>();
 }
 
@@ -601,6 +669,7 @@ void BeamModuleAssembler::emit_i_bs_match(ArgLabel const &Fail,
                                           ArgRegister const &Ctx,
                                           Span<ArgVal> const &List) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_bs_match_test_heap(ArgLabel const &Fail,
@@ -609,4 +678,5 @@ void BeamModuleAssembler::emit_i_bs_match_test_heap(ArgLabel const &Fail,
                                                     ArgWord const &Live,
                                                     Span<ArgVal> const &List) {
     // TODO
+    ASSERT(false);
 }

--- a/erts/emulator/beam/jit/arm/32/instr_call.cpp
+++ b/erts/emulator/beam/jit/arm/32/instr_call.cpp
@@ -27,27 +27,33 @@ extern "C"
 
 void BeamGlobalAssembler::emit_dispatch_return() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_dispatch_return() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_return() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_move_deallocate_return() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_call(const ArgLabel &CallTarget) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_call_last(const ArgLabel &CallTarget,
                                            const ArgWord &Deallocate) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_move_call_last(const ArgYRegister &Src,
@@ -55,10 +61,12 @@ void BeamModuleAssembler::emit_move_call_last(const ArgYRegister &Src,
                                               const ArgLabel &CallTarget,
                                               const ArgWord &Deallocate) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_call_only(const ArgLabel &CallTarget) {
     // TODO
+    ASSERT(false);
 }
 
 /* Handles save_calls for remote calls. When the active code index is
@@ -68,19 +76,23 @@ void BeamModuleAssembler::emit_i_call_only(const ArgLabel &CallTarget) {
  * be preserved since this runs between caller and callee. */
 void BeamGlobalAssembler::emit_dispatch_save_calls_export() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_call_ext(const ArgExport &Exp) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_call_ext_only(const ArgExport &Exp) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_call_ext_last(const ArgExport &Exp,
                                                const ArgWord &Deallocate) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_move_call_ext_last(const ArgYRegister &Src,
@@ -88,40 +100,48 @@ void BeamModuleAssembler::emit_move_call_ext_last(const ArgYRegister &Src,
                                                   const ArgExport &Exp,
                                                   const ArgWord &Deallocate) {
     // TODO
+    ASSERT(false);
 }
 
 static ErtsCodeMFA apply3_mfa = {am_erlang, am_apply, 3};
 
 arm::Mem BeamModuleAssembler::emit_variable_apply(bool includeI) {
     // TODO
+    ASSERT(false);
     arm::Mem m;
     return m;
 }
 
 void BeamModuleAssembler::emit_i_apply() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_apply_last(const ArgWord &Deallocate) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_apply_only() {
     // TODO
+    ASSERT(false);
 }
 
 arm::Mem BeamModuleAssembler::emit_fixed_apply(const ArgWord &Arity,
                                                bool includeI) {
     // TODO
+    ASSERT(false);
     arm::Mem m;
     return m;
 }
 
 void BeamModuleAssembler::emit_apply(const ArgWord &Arity) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_apply_last(const ArgWord &Arity,
                                           const ArgWord &Deallocate) {
     // TODO
+    ASSERT(false);
 }

--- a/erts/emulator/beam/jit/arm/32/instr_common.cpp
+++ b/erts/emulator/beam/jit/arm/32/instr_common.cpp
@@ -72,10 +72,12 @@ using namespace asmjit;
 
 void BeamModuleAssembler::emit_error(int reason) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_error(int reason, const ArgSource &Src) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_gc_test_preserve(const ArgWord &Need,
@@ -83,82 +85,98 @@ void BeamModuleAssembler::emit_gc_test_preserve(const ArgWord &Need,
                                                 const ArgSource &Preserve,
                                                 a32::Gp preserve_reg) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_gc_test(const ArgWord &Ns,
                                        const ArgWord &Nh,
                                        const ArgWord &Live) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_validate(const ArgWord &Arity) {
     // TODO
+    ASSERT(false);
 }
 
 /* Instrs */
 
 void BeamModuleAssembler::emit_i_validate(const ArgWord &Arity) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_allocate_heap(const ArgWord &NeedStack,
                                              const ArgWord &NeedHeap,
                                              const ArgWord &Live) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_allocate(const ArgWord &NeedStack,
                                         const ArgWord &Live) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_deallocate(const ArgWord &Deallocate) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_test_heap(const ArgWord &Nh,
                                          const ArgWord &Live) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_normal_exit() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_continue_exit() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_get_list(const ArgRegister &Src,
                                         const ArgRegister &Hd,
                                         const ArgRegister &Tl) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_get_hd(const ArgRegister &Src,
                                       const ArgRegister &Hd) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_get_tl(const ArgRegister &Src,
                                       const ArgRegister &Tl) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_get(const ArgSource &Src,
                                      const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_get_hash(const ArgConstant &Src,
                                           const ArgWord &Hash,
                                           const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 /* Store the untagged pointer to a tuple in ARG1. */
 void BeamModuleAssembler::emit_load_tuple_ptr(const ArgSource &Src) {
     // TODO
+    ASSERT(false);
 }
 
 #ifdef DEBUG
@@ -167,6 +185,7 @@ void BeamModuleAssembler::emit_load_tuple_ptr(const ArgSource &Src) {
 void BeamModuleAssembler::emit_tuple_assertion(const ArgSource &Src,
                                                a32::Gp tuple_reg) {
     // TODO
+    ASSERT(false);
 }
 #endif
 
@@ -176,6 +195,7 @@ void BeamModuleAssembler::emit_i_get_tuple_element(const ArgSource &Src,
                                                    const ArgWord &Element,
                                                    const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_get_tuple_element_swap(
@@ -184,6 +204,7 @@ void BeamModuleAssembler::emit_get_tuple_element_swap(
         const ArgRegister &Dst,
         const ArgRegister &OtherDst) {
     // TODO
+    ASSERT(false);
 }
 
 /* Fetch two consecutive tuple elements from the tuple pointed to by
@@ -193,21 +214,25 @@ void BeamModuleAssembler::emit_get_two_tuple_elements(const ArgSource &Src,
                                                       const ArgRegister &Dst1,
                                                       const ArgRegister &Dst2) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_init_yregs(const ArgWord &Size,
                                           const Span<ArgVal> &args) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_trim(const ArgWord &Words,
                                     const ArgWord &Remaining) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_move(const ArgSource &Src,
                                       const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_move_two_trim(const ArgYRegister &Src1,
@@ -216,12 +241,14 @@ void BeamModuleAssembler::emit_move_two_trim(const ArgYRegister &Src1,
                                              const ArgRegister &Dst2,
                                              const ArgWord &Words) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_move_trim(const ArgSource &Src,
                                          const ArgRegister &Dst,
                                          const ArgWord &Words) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_store_two_values(const ArgSource &Src1,
@@ -229,6 +256,7 @@ void BeamModuleAssembler::emit_store_two_values(const ArgSource &Src1,
                                                 const ArgSource &Src2,
                                                 const ArgRegister &Dst2) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_load_two_xregs(const ArgRegister &Src1,
@@ -236,17 +264,20 @@ void BeamModuleAssembler::emit_load_two_xregs(const ArgRegister &Src1,
                                               const ArgRegister &Src2,
                                               const ArgXRegister &Dst2) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_swap(const ArgRegister &R1,
                                     const ArgRegister &R2) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_swap2(const ArgRegister &R1,
                                      const ArgRegister &R2,
                                      const ArgRegister &R3) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_swap3(const ArgRegister &R1,
@@ -254,6 +285,7 @@ void BeamModuleAssembler::emit_swap3(const ArgRegister &R1,
                                      const ArgRegister &R3,
                                      const ArgRegister &R4) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_swap4(const ArgRegister &R1,
@@ -262,16 +294,19 @@ void BeamModuleAssembler::emit_swap4(const ArgRegister &R1,
                                      const ArgRegister &R4,
                                      const ArgRegister &R5) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_node(const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_put_list(const ArgSource &Hd,
                                         const ArgSource &Tl,
                                         const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_put_list_deallocate(const ArgSource &Hd,
@@ -279,6 +314,7 @@ void BeamModuleAssembler::emit_put_list_deallocate(const ArgSource &Hd,
                                                    const ArgRegister &Dst,
                                                    const ArgWord &Deallocate) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_put_list2(const ArgSource &Hd1,
@@ -286,22 +322,26 @@ void BeamModuleAssembler::emit_put_list2(const ArgSource &Hd1,
                                          const ArgSource &Tl,
                                          const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_put_tuple2(const ArgRegister &Dst,
                                           const ArgWord &Arity,
                                           const Span<ArgVal> &args) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_self(const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_copy_words_increment(a32::Gp from,
                                                     a32::Gp to,
                                                     size_t count) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_update_record(const ArgAtom &Hint,
@@ -311,6 +351,7 @@ void BeamModuleAssembler::emit_update_record(const ArgAtom &Hint,
                                              const ArgWord &UpdateCount,
                                              const Span<ArgVal> &updates) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_update_record_in_place(
@@ -320,97 +361,116 @@ void BeamModuleAssembler::emit_update_record_in_place(
         const ArgWord &UpdateCount,
         const Span<ArgVal> &updates) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_set_tuple_element(const ArgSource &Element,
                                                  const ArgRegister &Tuple,
                                                  const ArgWord &Offset) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_is_nonempty_list(const ArgLabel &Fail,
                                                 const ArgRegister &Src) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_jump(const ArgLabel &Fail) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_is_atom(const ArgLabel &Fail,
                                        const ArgSource &Src) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_is_boolean(const ArgLabel &Fail,
                                           const ArgSource &Src) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_is_bitstring(const ArgLabel &Fail,
                                             const ArgSource &Src) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_is_binary(const ArgLabel &Fail,
                                          const ArgSource &Src) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_is_float(const ArgLabel &Fail,
                                         const ArgSource &Src) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_is_function(const ArgLabel &Fail,
                                            const ArgRegister &Src) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_is_function2(const ArgLabel &Fail,
                                             const ArgSource &Src,
                                             const ArgSource &Arity) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_is_integer(const ArgLabel &Fail,
                                           const ArgSource &Src) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_is_list(const ArgLabel &Fail,
                                        const ArgSource &Src) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_is_map(const ArgLabel &Fail,
                                       const ArgSource &Src) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_is_nil(const ArgLabel &Fail,
                                       const ArgRegister &Src) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_is_number(const ArgLabel &Fail,
                                          const ArgSource &Src) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_is_pid(const ArgLabel &Fail,
                                       const ArgSource &Src) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_is_port(const ArgLabel &Fail,
                                        const ArgSource &Src) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_is_reference(const ArgLabel &Fail,
                                             const ArgSource &Src) {
     // TODO
+    ASSERT(false);
 }
 
 /* Note: This instruction leaves the untagged pointer to the tuple in
@@ -420,6 +480,7 @@ void BeamModuleAssembler::emit_i_is_tagged_tuple(const ArgLabel &Fail,
                                                  const ArgWord &Arity,
                                                  const ArgAtom &Tag) {
     // TODO
+    ASSERT(false);
 }
 
 /* Note: This instruction leaves the untagged pointer to the tuple in
@@ -430,6 +491,7 @@ void BeamModuleAssembler::emit_i_is_tagged_tuple_ff(const ArgLabel &NotTuple,
                                                     const ArgWord &Arity,
                                                     const ArgAtom &Tag) {
     // TODO
+    ASSERT(false);
 }
 
 /* Note: This instruction leaves the untagged pointer to the tuple in
@@ -437,6 +499,7 @@ void BeamModuleAssembler::emit_i_is_tagged_tuple_ff(const ArgLabel &NotTuple,
 void BeamModuleAssembler::emit_i_is_tuple(const ArgLabel &Fail,
                                           const ArgSource &Src) {
     // TODO
+    ASSERT(false);
 }
 
 /* Note: This instruction leaves the untagged pointer to the tuple in
@@ -445,6 +508,7 @@ void BeamModuleAssembler::emit_i_is_tuple_of_arity(const ArgLabel &Fail,
                                                    const ArgSource &Src,
                                                    const ArgWord &Arity) {
     // TODO
+    ASSERT(false);
 }
 
 /* Note: This instruction leaves the untagged pointer to the tuple in
@@ -454,6 +518,7 @@ void BeamModuleAssembler::emit_i_is_tuple_of_arity_ff(const ArgLabel &NotTuple,
                                                       const ArgSource &Src,
                                                       const ArgWord &Arity) {
     // TODO
+    ASSERT(false);
 }
 
 /* Note: This instruction leaves the untagged pointer to the tuple in
@@ -462,6 +527,7 @@ void BeamModuleAssembler::emit_i_test_arity(const ArgLabel &Fail,
                                             const ArgSource &Src,
                                             const ArgWord &Arity) {
     // TODO
+    ASSERT(false);
 }
 
 /*
@@ -472,6 +538,7 @@ void BeamModuleAssembler::emit_i_test_arity(const ArgLabel &Fail,
  */
 void BeamGlobalAssembler::emit_is_eq_exact_list_shared() {
     // TODO
+    ASSERT(false);
 }
 
 /*
@@ -482,30 +549,35 @@ void BeamGlobalAssembler::emit_is_eq_exact_list_shared() {
  */
 void BeamGlobalAssembler::emit_is_eq_exact_shallow_boxed_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_is_eq_exact(const ArgLabel &Fail,
                                            const ArgSource &X,
                                            const ArgSource &Y) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_is_ne_exact(const ArgLabel &Fail,
                                            const ArgSource &X,
                                            const ArgSource &Y) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_is_eq(const ArgLabel &Fail,
                                      const ArgSource &X,
                                      const ArgSource &Y) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_is_ne(const ArgLabel &Fail,
                                      const ArgSource &X,
                                      const ArgSource &Y) {
     // TODO
+    ASSERT(false);
 }
 
 /*
@@ -516,18 +588,21 @@ void BeamModuleAssembler::emit_is_ne(const ArgLabel &Fail,
  */
 void BeamGlobalAssembler::emit_arith_compare_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_is_lt(const ArgLabel &Fail,
                                      const ArgSource &LHS,
                                      const ArgSource &RHS) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_is_ge(const ArgLabel &Fail,
                                      const ArgSource &LHS,
                                      const ArgSource &RHS) {
     // TODO
+    ASSERT(false);
 }
 
 /*
@@ -539,6 +614,7 @@ void BeamModuleAssembler::emit_is_ge(const ArgLabel &Fail,
  */
 void BeamGlobalAssembler::emit_is_in_range_shared() {
     // TODO
+    ASSERT(false);
 }
 
 /*
@@ -550,6 +626,7 @@ void BeamModuleAssembler::emit_is_in_range(ArgLabel const &Small,
                                            ArgConstant const &Min,
                                            ArgConstant const &Max) {
     // TODO
+    ASSERT(false);
 }
 
 /*
@@ -561,6 +638,7 @@ void BeamModuleAssembler::emit_is_in_range(ArgLabel const &Small,
  */
 void BeamGlobalAssembler::emit_is_ge_lt_shared() {
     // TODO
+    ASSERT(false);
 }
 
 /*
@@ -580,6 +658,7 @@ void BeamModuleAssembler::emit_is_ge_lt(ArgLabel const &Fail1,
                                         ArgConstant const &A,
                                         ArgConstant const &B) {
     // TODO
+    ASSERT(false);
 }
 
 /*
@@ -591,6 +670,7 @@ void BeamModuleAssembler::emit_is_ge_ge(ArgLabel const &Fail1,
                                         ArgConstant const &A,
                                         ArgConstant const &B) {
     // TODO
+    ASSERT(false);
 }
 
 /*
@@ -606,6 +686,7 @@ void BeamModuleAssembler::emit_is_int_in_range(ArgLabel const &Fail,
                                                ArgConstant const &Min,
                                                ArgConstant const &Max) {
     // TODO
+    ASSERT(false);
 }
 
 /*
@@ -615,47 +696,58 @@ void BeamModuleAssembler::emit_is_int_ge(ArgLabel const &Fail,
                                          ArgRegister const &Src,
                                          ArgConstant const &Min) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_badmatch(const ArgSource &Src) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_case_end(const ArgSource &Src) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_system_limit_body() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_if_end() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_badrecord(const ArgSource &Src) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_catch(const ArgYRegister &Y,
                                      const ArgCatch &Handler) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamGlobalAssembler::emit_catch_end_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_catch_end(const ArgYRegister &CatchTag) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_try_end(const ArgYRegister &CatchTag) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_try_end_deallocate(const ArgWord &Deallocate) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_try_end_move_deallocate(
@@ -663,33 +755,40 @@ void BeamModuleAssembler::emit_try_end_move_deallocate(
         const ArgRegister &Dst,
         const ArgWord &Deallocate) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_try_case(const ArgYRegister &CatchTag) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_try_case_end(const ArgSource &Src) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamGlobalAssembler::emit_raise_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_raise(const ArgSource &Trace,
                                      const ArgSource &Value) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_build_stacktrace() {
     // TODO
+    ASSERT(false);
 }
 
 /* This instruction has the same semantics as the erlang:raise/3 BIF,
  * except that it can rethrow a raw stack backtrace. */
 void BeamModuleAssembler::emit_raw_raise() {
     // TODO
+    ASSERT(false);
 }
 
 #define TEST_YIELD_RETURN_OFFSET                                               \
@@ -699,24 +798,30 @@ void BeamModuleAssembler::emit_raw_raise() {
 /* ARG3 = current_label */
 void BeamGlobalAssembler::emit_i_test_yield_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_test_yield() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_yield() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_perf_counter() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_mark_unreachable() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_coverage(void *coverage, Uint index, Uint size) {
     // TODO
+    ASSERT(false);
 }

--- a/erts/emulator/beam/jit/arm/32/instr_float.cpp
+++ b/erts/emulator/beam/jit/arm/32/instr_float.cpp
@@ -30,6 +30,7 @@ extern "C"
  * Clobbers d30 and d31. */
 void BeamGlobalAssembler::emit_check_float_error() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_float_instr(uint32_t instId,
@@ -37,6 +38,7 @@ void BeamModuleAssembler::emit_float_instr(uint32_t instId,
                                            const ArgFRegister &RHS,
                                            const ArgFRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 /* * * * */
@@ -44,48 +46,57 @@ void BeamModuleAssembler::emit_float_instr(uint32_t instId,
 void BeamModuleAssembler::emit_fload(const ArgSource &Src,
                                      const ArgFRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_fstore(const ArgFRegister &Src,
                                       const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 /* ARG1 = source term */
 void BeamGlobalAssembler::emit_fconv_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_fconv(const ArgSource &Src,
                                      const ArgFRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_fadd(const ArgFRegister &LHS,
                                       const ArgFRegister &RHS,
                                       const ArgFRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_fsub(const ArgFRegister &LHS,
                                       const ArgFRegister &RHS,
                                       const ArgFRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_fmul(const ArgFRegister &LHS,
                                       const ArgFRegister &RHS,
                                       const ArgFRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_fdiv(const ArgFRegister &LHS,
                                       const ArgFRegister &RHS,
                                       const ArgFRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_fnegate(const ArgFRegister &Src,
                                          const ArgFRegister &Dst) {
     // TODO
+    ASSERT(false);
 }

--- a/erts/emulator/beam/jit/arm/32/instr_fun.cpp
+++ b/erts/emulator/beam/jit/arm/32/instr_fun.cpp
@@ -31,6 +31,7 @@
  *        can't use LR (x30) for this because tail calls point elsewhere. */
 void BeamGlobalAssembler::emit_unloaded_fun() {
     // TODO
+    ASSERT(false);
 }
 
 /* Handles errors for `call_fun`. Assumes that we're running on the Erlang
@@ -42,6 +43,7 @@ void BeamGlobalAssembler::emit_unloaded_fun() {
  *        can't use LR (x30) for this because tail calls point elsewhere. */
 void BeamGlobalAssembler::emit_handle_call_fun_error() {
     // TODO
+    ASSERT(false);
 }
 
 /* Handles save_calls for local funs, which is a side-effect of our calling
@@ -51,6 +53,7 @@ void BeamGlobalAssembler::emit_handle_call_fun_error() {
  * will land here. */
 void BeamGlobalAssembler::emit_dispatch_save_calls_fun() {
     // TODO
+    ASSERT(false);
 }
 
 /* `call_fun` instructions land here to set up their environment before jumping
@@ -65,6 +68,7 @@ void BeamModuleAssembler::emit_i_lambda_trampoline(const ArgLambda &Lambda,
                                                    const ArgWord &Arity,
                                                    const ArgWord &NumFree) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_make_fun3(const ArgLambda &Lambda,
@@ -73,22 +77,27 @@ void BeamModuleAssembler::emit_i_make_fun3(const ArgLambda &Lambda,
                                            const ArgWord &NumFree,
                                            const Span<ArgVal> &env) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamGlobalAssembler::emit_apply_fun_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_apply_fun() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_apply_fun_last(const ArgWord &Deallocate) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_apply_fun_only() {
     // TODO
+    ASSERT(false);
 }
 
 /* Assumes that:
@@ -97,6 +106,7 @@ void BeamModuleAssembler::emit_i_apply_fun_only() {
 a32::Gp BeamModuleAssembler::emit_call_fun(bool skip_box_test,
                                            bool skip_header_test) {
     // TODO
+    ASSERT(false);
     a32::Gp reg;
     return reg;
 }
@@ -105,6 +115,7 @@ void BeamModuleAssembler::emit_i_call_fun2(const ArgVal &Tag,
                                            const ArgWord &Arity,
                                            const ArgRegister &Func) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_call_fun2_last(const ArgVal &Tag,
@@ -112,18 +123,22 @@ void BeamModuleAssembler::emit_i_call_fun2_last(const ArgVal &Tag,
                                                 const ArgRegister &Func,
                                                 const ArgWord &Deallocate) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_call_fun(const ArgWord &Arity) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_call_fun_last(const ArgWord &Arity,
                                                const ArgWord &Deallocate) {
     // TODO
+    ASSERT(false);
 }
 
 /* Psuedo-instruction for signalling lambda load errors. Never actually runs. */
 void BeamModuleAssembler::emit_i_lambda_error(const ArgWord &Dummy) {
     // TODO
+    ASSERT(false);
 }

--- a/erts/emulator/beam/jit/arm/32/instr_guard_bifs.cpp
+++ b/erts/emulator/beam/jit/arm/32/instr_guard_bifs.cpp
@@ -49,6 +49,7 @@ using namespace asmjit;
 /* Raise a badarg exception for the given MFA. */
 void BeamGlobalAssembler::emit_raise_badarg(const ErtsCodeMFA *mfa) {
     // TODO
+    ASSERT(false);
 }
 
 /* ================================================================
@@ -61,15 +62,18 @@ void BeamGlobalAssembler::emit_raise_badarg(const ErtsCodeMFA *mfa) {
 
 void BeamGlobalAssembler::emit_bif_is_eq_exact_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamGlobalAssembler::emit_bif_is_ne_exact_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_cond_to_bool(arm::CondCode cc,
                                             const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_cmp_immed_to_bool(arm::CondCode cc,
@@ -77,18 +81,21 @@ void BeamModuleAssembler::emit_cmp_immed_to_bool(arm::CondCode cc,
                                                  const ArgSource &RHS,
                                                  const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_bif_is_eq_exact(const ArgRegister &LHS,
                                                const ArgSource &RHS,
                                                const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_bif_is_ne_exact(const ArgRegister &LHS,
                                                const ArgSource &RHS,
                                                const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_bif_is_ge_lt(arm::CondCode cc,
@@ -96,18 +103,21 @@ void BeamModuleAssembler::emit_bif_is_ge_lt(arm::CondCode cc,
                                             const ArgSource &RHS,
                                             const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_bif_is_ge(const ArgSource &LHS,
                                          const ArgSource &RHS,
                                          const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_bif_is_lt(const ArgSource &LHS,
                                          const ArgSource &RHS,
                                          const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 /* ================================================================
@@ -117,6 +127,7 @@ void BeamModuleAssembler::emit_bif_is_lt(const ArgSource &LHS,
 
 void BeamGlobalAssembler::emit_handle_and_error() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_bif_and(const ArgLabel &Fail,
@@ -124,6 +135,7 @@ void BeamModuleAssembler::emit_bif_and(const ArgLabel &Fail,
                                        const ArgSource &Src2,
                                        const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 /* ================================================================
@@ -132,16 +144,19 @@ void BeamModuleAssembler::emit_bif_and(const ArgLabel &Fail,
  */
 void BeamGlobalAssembler::emit_bif_bit_size_helper(Label error) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamGlobalAssembler::emit_bif_bit_size_body() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_bif_bit_size(const ArgLabel &Fail,
                                             const ArgSource &Src,
                                             const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 /* ================================================================
@@ -151,12 +166,14 @@ void BeamModuleAssembler::emit_bif_bit_size(const ArgLabel &Fail,
 
 void BeamGlobalAssembler::emit_bif_byte_size_body() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_bif_byte_size(const ArgLabel &Fail,
                                              const ArgSource &Src,
                                              const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 /* ================================================================
@@ -172,18 +189,22 @@ void BeamModuleAssembler::emit_bif_byte_size(const ArgLabel &Fail,
  */
 void BeamGlobalAssembler::emit_bif_element_helper(Label fail) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamGlobalAssembler::emit_bif_element_body_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamGlobalAssembler::emit_bif_element_guard_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamGlobalAssembler::emit_handle_element_error_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_bif_element(const ArgLabel &Fail,
@@ -191,6 +212,7 @@ void BeamModuleAssembler::emit_bif_element(const ArgLabel &Fail,
                                            const ArgSource &Tuple,
                                            const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 /* ================================================================
@@ -200,11 +222,13 @@ void BeamModuleAssembler::emit_bif_element(const ArgLabel &Fail,
 
 void BeamGlobalAssembler::emit_handle_hd_error() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_bif_hd(const ArgSource &Src,
                                       const ArgRegister &Hd) {
     // TODO
+    ASSERT(false);
 }
 
 /* ================================================================
@@ -218,6 +242,7 @@ void BeamModuleAssembler::emit_bif_is_map_key(const ArgWord &Bif,
                                               const ArgSource &Src,
                                               const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 /* ================================================================
@@ -227,10 +252,12 @@ void BeamModuleAssembler::emit_bif_is_map_key(const ArgWord &Bif,
 
 void BeamGlobalAssembler::emit_handle_map_get_badmap() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamGlobalAssembler::emit_handle_map_get_badkey() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_bif_map_get(const ArgLabel &Fail,
@@ -238,6 +265,7 @@ void BeamModuleAssembler::emit_bif_map_get(const ArgLabel &Fail,
                                            const ArgSource &Src,
                                            const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 /* ================================================================
@@ -247,12 +275,14 @@ void BeamModuleAssembler::emit_bif_map_get(const ArgLabel &Fail,
 
 void BeamGlobalAssembler::emit_handle_map_size_error() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_bif_map_size(const ArgLabel &Fail,
                                             const ArgSource &Src,
                                             const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 /* ================================================================
@@ -266,18 +296,21 @@ void BeamModuleAssembler::emit_bif_min_max(arm::CondCode cc,
                                            const ArgSource &RHS,
                                            const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_bif_max(const ArgSource &LHS,
                                        const ArgSource &RHS,
                                        const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_bif_min(const ArgSource &LHS,
                                        const ArgSource &RHS,
                                        const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 /* ================================================================
@@ -287,12 +320,14 @@ void BeamModuleAssembler::emit_bif_min(const ArgSource &LHS,
 
 void BeamGlobalAssembler::emit_handle_node_error() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_bif_node(const ArgLabel &Fail,
                                         const ArgRegister &Src,
                                         const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 /* ================================================================
@@ -302,12 +337,14 @@ void BeamModuleAssembler::emit_bif_node(const ArgLabel &Fail,
 
 void BeamGlobalAssembler::emit_handle_not_error() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_bif_not(const ArgLabel &Fail,
                                        const ArgRegister &Src,
                                        const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 /* ================================================================
@@ -317,6 +354,7 @@ void BeamModuleAssembler::emit_bif_not(const ArgLabel &Fail,
 
 void BeamGlobalAssembler::emit_handle_or_error() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_bif_or(const ArgLabel &Fail,
@@ -324,6 +362,7 @@ void BeamModuleAssembler::emit_bif_or(const ArgLabel &Fail,
                                       const ArgSource &Src2,
                                       const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 /* ================================================================
@@ -333,11 +372,13 @@ void BeamModuleAssembler::emit_bif_or(const ArgLabel &Fail,
 
 void BeamGlobalAssembler::emit_handle_tl_error() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_bif_tl(const ArgSource &Src,
                                       const ArgRegister &Tl) {
     // TODO
+    ASSERT(false);
 }
 
 /* ================================================================
@@ -347,18 +388,22 @@ void BeamModuleAssembler::emit_bif_tl(const ArgSource &Src,
 
 void BeamGlobalAssembler::emit_bif_tuple_size_helper(Label fail) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamGlobalAssembler::emit_bif_tuple_size_body() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamGlobalAssembler::emit_bif_tuple_size_guard() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_bif_tuple_size(const ArgLabel &Fail,
                                               const ArgRegister &Src,
                                               const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }

--- a/erts/emulator/beam/jit/arm/32/instr_map.cpp
+++ b/erts/emulator/beam/jit/arm/32/instr_map.cpp
@@ -38,6 +38,7 @@ extern "C"
  * Result in ARG3. Clobbers TMP1. */
 void BeamGlobalAssembler::emit_internal_hash_helper() {
     // TODO
+    ASSERT(false);
 }
 
 /* ARG1 = untagged hash map root
@@ -48,6 +49,7 @@ void BeamGlobalAssembler::emit_internal_hash_helper() {
  * Result is returned in RET. ZF is set on success. */
 void BeamGlobalAssembler::emit_hashmap_get_element() {
     // TODO
+    ASSERT(false);
 }
 
 /* ARG1 = untagged flat map
@@ -57,10 +59,12 @@ void BeamGlobalAssembler::emit_hashmap_get_element() {
  * Result is returned in ARG1. ZF is set on success. */
 void BeamGlobalAssembler::emit_flatmap_get_element() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamGlobalAssembler::emit_new_map_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_new_map(const ArgRegister &Dst,
@@ -68,6 +72,7 @@ void BeamModuleAssembler::emit_new_map(const ArgRegister &Dst,
                                        const ArgWord &Size,
                                        const Span<ArgVal> &args) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_new_small_map_lit(const ArgRegister &Dst,
@@ -76,6 +81,7 @@ void BeamModuleAssembler::emit_i_new_small_map_lit(const ArgRegister &Dst,
                                                    const ArgWord &Size,
                                                    const Span<ArgVal> &args) {
     // TODO
+    ASSERT(false);
 }
 
 /* ARG1 = map
@@ -84,6 +90,7 @@ void BeamModuleAssembler::emit_i_new_small_map_lit(const ArgRegister &Dst,
  * Result is returned in RET. ZF is set on success. */
 void BeamGlobalAssembler::emit_i_get_map_element_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_get_map_element(const ArgLabel &Fail,
@@ -91,6 +98,7 @@ void BeamModuleAssembler::emit_i_get_map_element(const ArgLabel &Fail,
                                                  const ArgRegister &Key,
                                                  const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_get_map_elements(const ArgLabel &Fail,
@@ -98,6 +106,7 @@ void BeamModuleAssembler::emit_i_get_map_elements(const ArgLabel &Fail,
                                                   const ArgWord &Size,
                                                   const Span<ArgVal> &args) {
     // TODO
+    ASSERT(false);
 }
 
 /* ARG1 = map
@@ -107,6 +116,7 @@ void BeamModuleAssembler::emit_i_get_map_elements(const ArgLabel &Fail,
  * Result is returned in RET. ZF is set on success. */
 void BeamGlobalAssembler::emit_i_get_map_element_hash_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_get_map_element_hash(const ArgLabel &Fail,
@@ -115,11 +125,13 @@ void BeamModuleAssembler::emit_i_get_map_element_hash(const ArgLabel &Fail,
                                                       const ArgWord &Hx,
                                                       const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 /* ARG3 = live registers, ARG4 = update vector size, ARG5 = update vector. */
 void BeamGlobalAssembler::emit_update_map_assoc_shared() {
     // TODO
+    ASSERT(false);
 }
 
 /* ARG2 = key
@@ -128,6 +140,7 @@ void BeamGlobalAssembler::emit_update_map_assoc_shared() {
  */
 void BeamGlobalAssembler::emit_update_map_single_assoc_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_update_map_assoc(const ArgSource &Src,
@@ -136,6 +149,7 @@ void BeamModuleAssembler::emit_update_map_assoc(const ArgSource &Src,
                                                 const ArgWord &Size,
                                                 const Span<ArgVal> &args) {
     // TODO
+    ASSERT(false);
 }
 
 /* ARG3 = live registers, ARG4 = update vector size, ARG5 = update vector.
@@ -143,6 +157,7 @@ void BeamModuleAssembler::emit_update_map_assoc(const ArgSource &Src,
  * Result is returned in RET, error is indicated by ZF. */
 void BeamGlobalAssembler::emit_update_map_exact_guard_shared() {
     // TODO
+    ASSERT(false);
 }
 
 /* ARG3 = live registers, ARG4 = update vector size, ARG5 = update vector.
@@ -150,6 +165,7 @@ void BeamGlobalAssembler::emit_update_map_exact_guard_shared() {
  * Does not return on error. */
 void BeamGlobalAssembler::emit_update_map_exact_body_shared() {
     // TODO
+    ASSERT(false);
 }
 
 /* ARG2 = key
@@ -159,6 +175,7 @@ void BeamGlobalAssembler::emit_update_map_exact_body_shared() {
  * Does not return on error. */
 void BeamGlobalAssembler::emit_update_map_single_exact_body_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_update_map_exact(const ArgSource &Src,
@@ -168,4 +185,5 @@ void BeamModuleAssembler::emit_update_map_exact(const ArgSource &Src,
                                                 const ArgWord &Size,
                                                 const Span<ArgVal> &args) {
     // TODO
+    ASSERT(false);
 }

--- a/erts/emulator/beam/jit/arm/32/instr_msg.cpp
+++ b/erts/emulator/beam/jit/arm/32/instr_msg.cpp
@@ -32,19 +32,23 @@ extern "C"
 
 void BeamModuleAssembler::emit_recv_marker_reserve(const ArgRegister &Dst) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_recv_marker_bind(const ArgRegister &Marker,
                                                 const ArgRegister &Reference) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_recv_marker_clear(const ArgRegister &Reference) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_recv_marker_use(const ArgRegister &Reference) {
     // TODO
+    ASSERT(false);
 }
 
 #ifdef ERTS_ENABLE_LOCK_CHECK
@@ -55,48 +59,59 @@ int erts_lc_proc_sig_receive_helper(Process *c_p,
                                     int *get_outp) {
     int res;
     // TODO
+    ASSERT(false);
     return res;
 }
 #endif
 
 void BeamGlobalAssembler::emit_i_loop_rec_shared() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_loop_rec(const ArgLabel &Wait) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_remove_message() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_loop_rec_end(const ArgLabel &Dest) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_wait_unlocked(const ArgLabel &Dest) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_wait_locked(const ArgLabel &Dest) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_wait_timeout_unlocked(const ArgSource &Src,
                                                      const ArgLabel &Dest) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_wait_timeout_locked(const ArgSource &Src,
                                                    const ArgLabel &Dest) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_timeout_locked() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_timeout() {
     // TODO
+    ASSERT(false);
 }

--- a/erts/emulator/beam/jit/arm/32/instr_select.cpp
+++ b/erts/emulator/beam/jit/arm/32/instr_select.cpp
@@ -28,6 +28,7 @@ using namespace asmjit;
 template<typename T>
 static constexpr bool isInt13(T value) {
     // TODO
+    ASSERT(false);
     return false;
 }
 
@@ -43,6 +44,7 @@ static constexpr bool isInt13(T value) {
  * of elements fitting in a 13-bit immediate. */
 static std::pair<UWord, int> plan_untag(const Span<ArgVal> &args) {
     // TODO
+    ASSERT(false);
     return std::pair<UWord, int>();
 }
 
@@ -54,6 +56,7 @@ const std::vector<ArgVal> BeamModuleAssembler::emit_select_untag(
         UWord base,
         int shift) {
     // TODO
+    ASSERT(false);
     return std::vector<ArgVal>();
 }
 
@@ -61,6 +64,7 @@ void BeamModuleAssembler::emit_linear_search(a32::Gp comparand,
                                              Label fail,
                                              const Span<ArgVal> &args) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_select_tuple_arity(const ArgRegister &Src,
@@ -68,6 +72,7 @@ void BeamModuleAssembler::emit_i_select_tuple_arity(const ArgRegister &Src,
                                                     const ArgWord &Size,
                                                     const Span<ArgVal> &args) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_select_val_lins(const ArgSource &Src,
@@ -75,6 +80,7 @@ void BeamModuleAssembler::emit_i_select_val_lins(const ArgSource &Src,
                                                  const ArgWord &Size,
                                                  const Span<ArgVal> &args) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_select_val_bins(const ArgSource &Src,
@@ -82,6 +88,7 @@ void BeamModuleAssembler::emit_i_select_val_bins(const ArgSource &Src,
                                                  const ArgWord &Size,
                                                  const Span<ArgVal> &args) {
     // TODO
+    ASSERT(false);
 }
 
 /*
@@ -94,6 +101,7 @@ void BeamModuleAssembler::emit_binsearch_nodes(a32::Gp reg,
                                                Label fail,
                                                const Span<ArgVal> &args) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_jump_on_val(const ArgSource &Src,
@@ -102,6 +110,7 @@ void BeamModuleAssembler::emit_i_jump_on_val(const ArgSource &Src,
                                              const ArgWord &Size,
                                              const Span<ArgVal> &args) {
     // TODO
+    ASSERT(false);
 }
 
 /*
@@ -122,4 +131,5 @@ void BeamModuleAssembler::emit_optimized_two_way_select(a32::Gp reg,
                                                         const ArgVal &value2,
                                                         const ArgVal &label) {
     // TODO
+    ASSERT(false);
 }

--- a/erts/emulator/beam/jit/arm/32/instr_trace.cpp
+++ b/erts/emulator/beam/jit/arm/32/instr_trace.cpp
@@ -32,6 +32,7 @@ extern "C"
  * ARG1 = export entry */
 void BeamGlobalAssembler::emit_generic_bp_global() {
     // TODO
+    ASSERT(false);
 }
 
 /* This function is called from the module header, which is in turn called from
@@ -41,6 +42,7 @@ void BeamGlobalAssembler::emit_generic_bp_global() {
  * See beam_asm.h for more details */
 void BeamGlobalAssembler::emit_generic_bp_local() {
     // TODO
+    ASSERT(false);
 }
 
 /* This function is called from the module header which is called from the
@@ -49,6 +51,7 @@ void BeamGlobalAssembler::emit_generic_bp_local() {
  * The only place that we can come to here is from generic_bp_local */
 void BeamGlobalAssembler::emit_debug_bp() {
     // TODO
+    ASSERT(false);
 }
 
 static void return_trace(Process *c_p,
@@ -57,20 +60,25 @@ static void return_trace(Process *c_p,
                          ErtsTracer tracer,
                          Eterm session_id) {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_return_trace() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_call_trace_return() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_return_to_trace() {
     // TODO
+    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_i_hibernate() {
     // TODO
+    ASSERT(false);
 }

--- a/erts/emulator/beam/jit/arm/32/process_main.cpp
+++ b/erts/emulator/beam/jit/arm/32/process_main.cpp
@@ -57,6 +57,8 @@ void BeamGlobalAssembler::emit_process_main() {
             getSchedulerRegRef(offsetof(ErtsSchedulerRegisters, start_time));
 
     // TODO
+    ASSERT(false);
+
     a.bind(do_schedule_local);
     a.bind(context_switch_local);
     comment("Context switch, unknown arity/MFA");


### PR DESCRIPTION
Code wil break during global function emitions

```
vagrant@vagrant:~/arm32-jit$ ./run_debug.sh 
beam/jit/arm/32/instr_fun.cpp:85:emit_apply_fun_shared() Assertion failed: false
qemu-arm: QEMU: Terminated via GDBstub
```