### PR TITLE
Emit arith_compare_shared

### DIFF
--- a/erts/emulator/beam/jit/arm/32/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/32/beam_asm.hpp
@@ -228,22 +228,25 @@ protected:
         ASSERT(false);
     }
 
-    /* We keep the first six X registers in machine registers. Some of those
-     * registers are callee-saved and some are caller-saved.
-     *
-     * We ignore the ones above `live` to reduce the save/restore traffic on
-     * these registers. It's enough for this figure to be at least as high as
-     * the number of actually live registers, and we default to all six
-     * registers when we don't know the exact number.
-     *
-     * Furthermore, we only save the callee-save registers when told to sync
-     * all registers with the `Update::eXRegs` flag, as this is very rarely
-     * needed. */
-
+    /*
+     * We save the Erlang Stack, Erlang Heap and FCALLS registers in the
+     * C structure of the current process (c_p)
+    */
     template<int Spec = 0>
     void emit_enter_runtime() {
-        // TODO
-        ASSERT(false);
+        ERTS_CT_ASSERT((Spec & (Update::eReductions | Update::eStack |
+                                Update::eHeap | Update::eXRegs)) == Spec);
+        if (Spec & Update::eStack) {
+            a.str(E, arm::Mem(c_p, offsetof(Process, stop)));
+        }
+        if (Spec & Update::eHeap) {
+            a.str(HTOP, arm::Mem(c_p, offsetof(Process, htop)));
+        }
+        if (Spec & Update::eReductions) {
+            a.str(FCALLS, arm::Mem(c_p, offsetof(Process, fcalls)));
+        }
+        // We do not have any X register cached in machine registers
+        // so nothiung else needs to be saved.
     }
 
     template<int Spec = 0>

--- a/erts/emulator/beam/jit/arm/32/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/32/beam_asm.hpp
@@ -149,6 +149,22 @@ protected:
 #endif
     }
 
+    void runtime_call(a32::Gp func, unsigned args) {
+        ASSERT(false);
+    }
+
+    template<typename T>
+    struct function_arity;
+    template<typename T, typename... Args>
+    struct function_arity<T(Args...)>
+            : std::integral_constant<int, sizeof...(Args)> {};
+
+    template<int expected_arity, typename T>
+    void runtime_call(T(*func)) {
+        static_assert(expected_arity == function_arity<T>());
+        ASSERT(false);
+    }
+
     constexpr arm::Mem getArgRef(const ArgRegister &arg) const {
         if (arg.isXRegister()) {
             return getXRef(arg.as<ArgXRegister>().get());
@@ -933,9 +949,7 @@ protected:
 
     template<int expected_arity, typename T>
     void runtime_call(T(*func)) {
-        static_assert(expected_arity == function_arity<T>());
-
-        a.bl(resolve_fragment((void (*)())func, disp128MB));
+        ASSERT(false);
     }
 
     bool isRegisterBacked(const ArgVal &arg) {

--- a/erts/emulator/beam/jit/arm/32/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/32/beam_asm.hpp
@@ -259,8 +259,17 @@ protected:
     }
 
     void emit_is_boxed(Label Fail, a32::Gp Src) {
-        // TODO
-        ASSERT(false);
+        const int bitNumber = 0;
+        ERTS_CT_ASSERT(_TAG_PRIMARY_MASK - TAG_PRIMARY_BOXED ==
+                       (1 << bitNumber));
+        // TST performs a AND operation, sets the Z flag to:
+        // if isZeroBit(result)
+        //     Z = 1
+        // else
+        //     Z = 0
+        a.tst(Src, imm(1 << bitNumber));
+        // Branch if Z == 0
+        a.b_ne(Fail);
     }
 
     void emit_is_not_boxed(Label Fail, a32::Gp Src) {

--- a/erts/emulator/beam/jit/arm/32/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/32/beam_asm.hpp
@@ -162,7 +162,8 @@ protected:
     template<int expected_arity, typename T>
     void runtime_call(T(*func)) {
         static_assert(expected_arity == function_arity<T>());
-        ASSERT(false);
+        mov_imm(TMP, func);
+        a.bx(TMP);
     }
 
     constexpr arm::Mem getArgRef(const ArgRegister &arg) const {

--- a/erts/emulator/beam/jit/arm/32/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/32/beam_asm.hpp
@@ -237,9 +237,19 @@ protected:
                                 Update::eHeap | Update::eXRegs)) == Spec);
         if (Spec & Update::eStack) {
             a.str(E, arm::Mem(c_p, offsetof(Process, stop)));
+        } else {
+#ifdef DEBUG
+        /* Store some garbage in the process structure to catch missing
+         * updates. */
+        a.str(active_code_ix, arm::Mem(c_p, offsetof(Process, stop)));
+#endif
         }
         if (Spec & Update::eHeap) {
             a.str(HTOP, arm::Mem(c_p, offsetof(Process, htop)));
+        } else {
+#ifdef DEBUG
+            a.str(active_code_ix, arm::Mem(c_p, offsetof(Process, htop)));
+#endif
         }
         if (Spec & Update::eReductions) {
             a.str(FCALLS, arm::Mem(c_p, offsetof(Process, fcalls)));

--- a/erts/emulator/beam/jit/arm/32/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/32/beam_asm.hpp
@@ -215,8 +215,12 @@ protected:
     }
 
     void emit_enter_runtime_frame() {
-        // TODO
-        ASSERT(false);
+        // We save the current frame pointer first
+        // and then the content of theLink Register on the stack
+        a.push(a32::GpList({a32::fp, a32::lr}));
+        // We modify the frame pointer register to point
+        // where we just stored the current frame pointer value
+        a.add(a32::fp, a32::sp, imm(4));
     }
 
     void emit_leave_runtime_frame() {

--- a/erts/emulator/beam/jit/arm/32/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/32/beam_asm.hpp
@@ -79,11 +79,10 @@ protected:
      * the aux_regs field to be addressed with an 8-bit displacement. */
     const a32::Gp scheduler_registers = a32::r4;
 
-    const a32::Gp E = a32::r7;
-
-    const a32::Gp c_p = a32::r8;
-    const a32::Gp FCALLS = a32::r9;
-    const a32::Gp HTOP = a32::r10;
+    const a32::Gp E = a32::r7; // Erlang Stack pointer
+    const a32::Gp c_p = a32::r8; // Current Process pointer
+    const a32::Gp FCALLS = a32::r9; // Function call counter (reductions)
+    const a32::Gp HTOP = a32::r10; // Erlang Heap pointer
 
     /* Local copy of the active code index.
      *
@@ -246,7 +245,7 @@ protected:
             a.str(FCALLS, arm::Mem(c_p, offsetof(Process, fcalls)));
         }
         // We do not have any X register cached in machine registers
-        // so nothiung else needs to be saved.
+        // so nothing else needs to be saved.
     }
 
     template<int Spec = 0>

--- a/erts/emulator/beam/jit/arm/32/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/32/beam_asm.hpp
@@ -240,8 +240,9 @@ protected:
     }
 
     void emit_leave_runtime_frame() {
-        // TODO
-        ASSERT(false);
+        // Restore the frame pointer and the return address
+        // This also updates the stack pointer
+        a.pop(a32::GpList({a32::fp, a32::pc}));
     }
 
     /*

--- a/erts/emulator/beam/jit/arm/32/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/32/beam_asm.hpp
@@ -277,8 +277,27 @@ protected:
 
     template<int Spec = 0>
     void emit_leave_runtime() {
-        // TODO
-        ASSERT(false);
+        ERTS_CT_ASSERT(
+            (Spec & (Update::eReductions | Update::eStack | Update::eHeap |
+                     Update::eXRegs | Update::eCodeIndex)) == Spec);
+        if (Spec & Update::eStack) {
+            a.ldr(E, arm::Mem(c_p, offsetof(Process, stop)));
+        }
+        if (Spec & Update::eHeap) {
+            a.ldr(HTOP, arm::Mem(c_p, offsetof(Process, htop)));
+        }
+        if (Spec & Update::eReductions) {
+            a.ldr(FCALLS, arm::Mem(c_p, offsetof(Process, fcalls)));
+        }
+
+        if (Spec & Update::eCodeIndex) {
+            /* Updates the local copy of the active code index, retaining
+             * save_calls if active. */
+            mov_imm(TMP, &the_active_code_index);
+            a.ldr(TMP, arm::Mem(TMP));
+            a.cmp(active_code_ix, imm(ERTS_SAVE_CALLS_CODE_IX));
+            a.mov_ne(active_code_ix, TMP);
+        }
     }
 
     void emit_is_cons(Label Fail, a32::Gp Src) {

--- a/erts/emulator/beam/jit/arm/32/instr_common.cpp
+++ b/erts/emulator/beam/jit/arm/32/instr_common.cpp
@@ -598,6 +598,7 @@ void BeamGlobalAssembler::emit_arith_compare_shared() {
     runtime_call<4>(erts_cmp_compound);
 
     emit_leave_runtime();
+    emit_leave_runtime_frame();
 }
 
 void BeamModuleAssembler::emit_is_lt(const ArgLabel &Fail,

--- a/erts/emulator/beam/jit/arm/32/instr_common.cpp
+++ b/erts/emulator/beam/jit/arm/32/instr_common.cpp
@@ -599,6 +599,10 @@ void BeamGlobalAssembler::emit_arith_compare_shared() {
 
     emit_leave_runtime();
     emit_leave_runtime_frame();
+
+    a.tst(ARG1, ARG1);
+
+    a.bx(a32::lr);
 }
 
 void BeamModuleAssembler::emit_is_lt(const ArgLabel &Fail,

--- a/erts/emulator/beam/jit/arm/32/instr_common.cpp
+++ b/erts/emulator/beam/jit/arm/32/instr_common.cpp
@@ -590,6 +590,7 @@ void BeamGlobalAssembler::emit_arith_compare_shared() {
     // We directly call erts_cmp_compound here instead of
     // trying to use faster alternatives.
     emit_enter_runtime_frame();
+    emit_enter_runtime();
 }
 
 void BeamModuleAssembler::emit_is_lt(const ArgLabel &Fail,

--- a/erts/emulator/beam/jit/arm/32/instr_common.cpp
+++ b/erts/emulator/beam/jit/arm/32/instr_common.cpp
@@ -587,8 +587,13 @@ void BeamModuleAssembler::emit_is_ne(const ArgLabel &Fail,
  * Result is returned in the flags.
  */
 void BeamGlobalAssembler::emit_arith_compare_shared() {
+    Label atom_compare = a.newLabel(), generic_compare = a.newLabel();
+
+    /* Are both floats?
+     *
+     * This is done first as relative comparisons on atoms doesn't make much
+     * sense. */
     // TODO
-    ASSERT(false);
 }
 
 void BeamModuleAssembler::emit_is_lt(const ArgLabel &Fail,

--- a/erts/emulator/beam/jit/arm/32/instr_common.cpp
+++ b/erts/emulator/beam/jit/arm/32/instr_common.cpp
@@ -587,21 +587,9 @@ void BeamModuleAssembler::emit_is_ne(const ArgLabel &Fail,
  * Result is returned in the flags.
  */
 void BeamGlobalAssembler::emit_arith_compare_shared() {
-    Label atom_compare = a.newLabel(), generic_compare = a.newLabel();
-
-    /* Are both floats?
-     *
-     * This is done first as relative comparisons on atoms doesn't make much
-     * sense. */
-
-    // We need to check if values are "boxed",
-    // that is if they are pointers to a header.
-    // If they are not boxed, we assume they are atoms and jump to atom_compare.
-    // First, we ORR the 2 registers to check if any of the 2 is not boxed both.
-    a.orr(TMP, ARG1, ARG2);
-    // Check if both are boxed, if this fails, jump to atom_compare.
-    emit_is_boxed(atom_compare, TMP);
-    // TODO
+    // We directly call erts_cmp_compound here instead of
+    // trying to use faster alternatives.
+    emit_enter_runtime_frame();
 }
 
 void BeamModuleAssembler::emit_is_lt(const ArgLabel &Fail,

--- a/erts/emulator/beam/jit/arm/32/instr_common.cpp
+++ b/erts/emulator/beam/jit/arm/32/instr_common.cpp
@@ -591,6 +591,11 @@ void BeamGlobalAssembler::emit_arith_compare_shared() {
     // trying to use faster alternatives.
     emit_enter_runtime_frame();
     emit_enter_runtime();
+
+    comment("erts_cmp_compound(X, Y, 0, 0);");
+    mov_imm(ARG3, 0);
+    mov_imm(ARG4, 0);
+    runtime_call<4>(erts_cmp_compound);
 }
 
 void BeamModuleAssembler::emit_is_lt(const ArgLabel &Fail,

--- a/erts/emulator/beam/jit/arm/32/instr_common.cpp
+++ b/erts/emulator/beam/jit/arm/32/instr_common.cpp
@@ -596,6 +596,8 @@ void BeamGlobalAssembler::emit_arith_compare_shared() {
     mov_imm(ARG3, 0);
     mov_imm(ARG4, 0);
     runtime_call<4>(erts_cmp_compound);
+
+    emit_leave_runtime();
 }
 
 void BeamModuleAssembler::emit_is_lt(const ArgLabel &Fail,

--- a/erts/emulator/beam/jit/arm/32/instr_common.cpp
+++ b/erts/emulator/beam/jit/arm/32/instr_common.cpp
@@ -593,6 +593,14 @@ void BeamGlobalAssembler::emit_arith_compare_shared() {
      *
      * This is done first as relative comparisons on atoms doesn't make much
      * sense. */
+
+    // We need to check if values are "boxed",
+    // that is if they are pointers to a header.
+    // If they are not boxed, we assume they are atoms and jump to atom_compare.
+    // First, we ORR the 2 registers to check if any of the 2 is not boxed both.
+    a.orr(TMP, ARG1, ARG2);
+    // Check if both are boxed, if this fails, jump to atom_compare.
+    emit_is_boxed(atom_compare, TMP);
     // TODO
 }
 

--- a/xcomp/erl-xcomp-arm-linux-custom.conf
+++ b/xcomp/erl-xcomp-arm-linux-custom.conf
@@ -76,7 +76,7 @@ erl_xcomp_configure_flags="${JIT} ${CRYPTO_CONFIG_OPTION} --without-termcap ${DI
 GDB_FLAGS='-ggdb3'
 
 # * `CC' - C compiler.
-CC="arm-linux-gnueabihf-gcc -march=armv7-a -mfpu=neon --sysroot=$ARM_SYSROOT"
+CC="arm-linux-gnueabihf-gcc -march=armv7-a -marm -mfpu=neon --sysroot=$ARM_SYSROOT"
 
 # WARININGS
 # The following warnings were observed and need attention:


### PR DESCRIPTION
## Main content
The plan for this function is to just call `erts_cmp_compound` that is able to compare any Eterm.
This means skipping all checks that are done to use other comparisons.

Main challenge here is to correctly manage the stack to call the C function.

## Extras

- New comments to better remind the role of key Callee-saved registers
- Fixed xcomp file, now correctly compiling all the code in `arm` mode
- Function `emit_is_boxed` was implemented although not used (for now)