### PR TITLE
[Arm32-JIT] Advanced call support to execute `erlang` module NIFs

### DIFF
--- a/erts/emulator/Makefile.in
+++ b/erts/emulator/Makefile.in
@@ -747,7 +747,8 @@ ESOCK_PRELOAD_BEAM = \
 	$(ERL_TOP)/erts/preloaded/ebin/prim_net.beam
 
 ifeq ($(JIT_ARCH_BITS), 32)
-PRELOAD_BEAM = $(ERL_TOP)/erts/preloaded/ebin/hello.beam
+PRELOAD_BEAM = $(ERL_TOP)/erts/preloaded/ebin/hello.beam \
+		$(ERL_TOP)/erts/preloaded/ebin/erlang.beam
 else
 PRELOAD_BEAM = $(ERL_TOP)/erts/preloaded/ebin/erts_code_purger.beam \
 		$(ERL_TOP)/erts/preloaded/ebin/erl_init.beam \

--- a/erts/emulator/beam/jit/arm/32/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/32/beam_asm.hpp
@@ -196,7 +196,7 @@ protected:
     }
     
     void aligned_call(Label target) {
-        a.blx(target);
+        a.bl(target);
     }
 
     void aligned_call(a32::Gp target) {

--- a/erts/emulator/beam/jit/arm/32/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/32/beam_asm.hpp
@@ -174,12 +174,36 @@ protected:
         a.bind(next);
 #endif
     }
-
+    
     void branch(arm::Mem target) {
         a.ldr(TMP, target);
         a.bx(TMP);
     }
+    
+    template<typename FuncPtr>
+    void aligned_call(FuncPtr(*target)) {
+        mov_imm(TMP, target);
+        a.blx(TMP);
+    }
+    
+    void aligned_call(Label target) {
+        a.blx(target);
+    }
 
+    void aligned_call(a32::Gp target) {
+        a.blx(target);
+    }
+
+    /* Calls the given address. In DEBUG builds, make
+     * sure that the CP is aligned. */
+    template<typename OperandType>
+    void aligned_call(OperandType target) {
+        ERTS_CT_ASSERT(_CPMASK == 3);
+        ASSERT(is_CP(a.offset()));
+        a.ldr(TMP, target);
+        a.blx(TMP);
+    }
+    
     void runtime_call(a32::Gp func, unsigned args) {
         ASSERT(false);
     }

--- a/erts/emulator/beam/jit/arm/32/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/32/beam_asm.hpp
@@ -1149,7 +1149,7 @@ protected:
     void runtime_call(T(*func)) {
         static_assert(expected_arity == function_arity<T>());
 
-        a.blx(resolve_fragment((void (*)())func, disp32MB));
+        a.bl(resolve_fragment((void (*)())func, disp32MB));
     }
 
     bool isRegisterBacked(const ArgVal &arg) {

--- a/erts/emulator/beam/jit/arm/32/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/32/beam_asm.hpp
@@ -480,15 +480,30 @@ protected:
     }
 
     void mov_imm(a32::Gp to, std::nullptr_t value) {
-        // TODO
-        //ASSERT(false);
-        emit_nyi("mov_imm");
+        (void)value;
+        mov_imm(to, 0);
     }
 
     void sub(a32::Gp to, a32::Gp src, int64_t val) {
-        // TODO
-        //ASSERT(false);
-        emit_nyi("sub");
+        if (val < 0) {
+            add(to, src, -val);
+        } else if (val == 0 && to != src) {
+            a.mov(to, src);
+        } else if (val < (1 << 24)) {
+            if (val & 0xFFF) {                   // subtract the lower 12 bits
+                a.sub(to, src, imm(val & 0xFFF));
+                src = to;
+            }
+
+            if (val & 0xFFF000) {                // subtract the upper 12 bits
+                a.sub(to, src, imm(val & 0xFFF000));
+            }
+        } else {
+            a32::Gp tmp = follow_size(TMP, to);
+
+            mov_imm(tmp, val);
+            a.sub(to, src, tmp);
+        }
     }
 
     void add(a32::Gp to, a32::Gp src, int32_t val) {

--- a/erts/emulator/beam/jit/arm/32/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/32/beam_asm.hpp
@@ -316,7 +316,7 @@ protected:
     template<int Spec = 0>
     void emit_enter_runtime() {
         ERTS_CT_ASSERT((Spec & (Update::eReductions | Update::eStack |
-                                Update::eHeap | Update::eXRegs)) == Spec);
+                                Update::eHeap)) == Spec);
         if (Spec & Update::eStack) {
             a.str(E, arm::Mem(c_p, offsetof(Process, stop)));
         } else {
@@ -344,7 +344,7 @@ protected:
     void emit_leave_runtime() {
         ERTS_CT_ASSERT(
             (Spec & (Update::eReductions | Update::eStack | Update::eHeap |
-                     Update::eXRegs | Update::eCodeIndex)) == Spec);
+                     Update::eCodeIndex)) == Spec);
         if (Spec & Update::eStack) {
             a.ldr(E, arm::Mem(c_p, offsetof(Process, stop)));
         }

--- a/erts/emulator/beam/jit/arm/32/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/32/beam_asm.hpp
@@ -306,7 +306,7 @@ protected:
     void emit_leave_runtime_frame() {
         // Restore the frame pointer and the return address
         // This also updates the stack pointer
-        a.pop(a32::GpList({a32::fp, a32::pc}));
+        a.pop(a32::GpList({a32::fp, a32::lr}));
     }
 
     /*

--- a/erts/emulator/beam/jit/arm/32/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/32/beam_asm.hpp
@@ -481,12 +481,14 @@ protected:
 
     void mov_imm(a32::Gp to, std::nullptr_t value) {
         // TODO
-        ASSERT(false);
+        //ASSERT(false);
+        emit_nyi("mov_imm");
     }
 
     void sub(a32::Gp to, a32::Gp src, int64_t val) {
         // TODO
-        ASSERT(false);
+        //ASSERT(false);
+        emit_nyi("sub");
     }
 
     void add(a32::Gp to, a32::Gp src, int32_t val) {
@@ -586,9 +588,9 @@ class BeamModuleAssembler : public BeamAssembler,
     /* Save the last PC for an error. */
     size_t last_error_offset = 0;
 
-    static constexpr ptrdiff_t STUB_CHECK_INTERVAL = 4 << 10;
+    static constexpr ptrdiff_t STUB_CHECK_INTERVAL = 1 << 10;
     static constexpr ptrdiff_t STUB_CHECK_INTERVAL_UNREACHABLE =
-            (4 << 10) - 128;
+            (1 << 10) - 128;
     size_t last_stub_check_offset = 0;
 
     /* Save the last known unreachable position. */
@@ -618,7 +620,10 @@ class BeamModuleAssembler : public BeamAssembler,
          *
          * Note that we subtract the size of one instruction to handle
          * backward displacements. */
-        dispUnknown = (32 << 10) - sizeof(Uint32) - STUB_CHECK_INTERVAL,
+        dispUnknown = (4 << 10) - sizeof(Uint32) - STUB_CHECK_INTERVAL,
+        
+        /* +- 4KB: `ldr` of 4-byte literal. */
+        disp4KB = (4 << 10) - sizeof(Uint32),
 
         /* +- 32MB: `b`, `bl`, `blx`, b.cond */
         disp32MB = (32 << 20) - sizeof(Uint32),
@@ -1158,7 +1163,7 @@ protected:
         if (arg.isLiteral()) {
             preserve_cache(
                     [&]() {
-                        a.ldr(tmp, embed_constant(arg, disp32MB));
+                        a.ldr(tmp, embed_constant(arg, disp4KB));
                     },
                     tmp);
             return Variable(tmp);
@@ -1183,7 +1188,7 @@ protected:
 
             preserve_cache(
                     [&]() {
-                        a.ldr(tmp, embed_constant(arg, disp32MB));
+                        a.ldr(tmp, embed_constant(arg, disp4KB));
                     },
                     tmp);
             return Variable(tmp);

--- a/erts/emulator/beam/jit/arm/32/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/32/beam_asm.hpp
@@ -175,6 +175,15 @@ protected:
 #endif
     }
     
+    /*
+     * Calls an Erlang function.
+     */
+    template<typename Any>
+    void erlang_call(Any Target) {
+        emit_assert_redzone_unused();
+        aligned_call(Target);
+    }
+    
     void branch(arm::Mem target) {
         a.ldr(TMP, target);
         a.bx(TMP);

--- a/erts/emulator/beam/jit/arm/32/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/32/beam_asm.hpp
@@ -622,8 +622,11 @@ class BeamModuleAssembler : public BeamAssembler,
          * backward displacements. */
         dispUnknown = (4 << 10) - sizeof(Uint32) - STUB_CHECK_INTERVAL,
         
-        /* +- 4KB: `ldr` of 4-byte literal. */
-        disp4KB = (4 << 10) - sizeof(Uint32),
+        /* +- 4KB: `ldr` of 4-byte literal.
+         * ARM LDR (literal) encodes offset from PC+8; valid range ±4095 bytes. 
+         * For such, we reduce further the range by 8 to be safe when applied
+         * as negative offset. */
+        disp4KB = (4 << 10) - 1 - 2 * sizeof(Uint32),
 
         /* +- 32MB: `b`, `bl`, `blx`, b.cond */
         disp32MB = (32 << 20) - sizeof(Uint32),

--- a/erts/emulator/beam/jit/arm/32/beam_asm_global.cpp
+++ b/erts/emulator/beam/jit/arm/32/beam_asm_global.cpp
@@ -203,8 +203,19 @@ void BeamModuleAssembler::emit_raise_exception(Label I,
 }
 
 void BeamGlobalAssembler::emit_process_exit() {
-    // TODO
-    emit_nyi("emit_process_exit");
+    emit_enter_runtime<Update::eHeapAlloc | Update::eReductions>();
+
+    a.mov(ARG1, c_p);
+    mov_imm(ARG2, 0);
+    mov_imm(ARG4, 0);
+    load_x_reg_array(ARG3);
+    runtime_call<4>(handle_error);
+
+    emit_leave_runtime<Update::eHeapAlloc | Update::eReductions>();
+
+    a.tst(ARG1, ARG1);
+    a.b_eq(labels[do_schedule]);
+    a.udf(0xdead);
 }
 
 /* You must have already done emit_leave_runtime_frame()! */

--- a/erts/emulator/beam/jit/arm/32/beam_asm_global.cpp
+++ b/erts/emulator/beam/jit/arm/32/beam_asm_global.cpp
@@ -121,8 +121,66 @@ void BeamGlobalAssembler::emit_bif_export_trap() {
  * ARG1 = export entry
  */
 void BeamGlobalAssembler::emit_export_trampoline() {
-    // TODO
-    emit_nyi("emit_export_trampoline");
+    Label call_bif = a.newLabel(), error_handler = a.newLabel();
+
+    /* What are we supposed to do? */
+    a.ldr(TMP, arm::Mem(ARG1, offsetof(Export, trampoline.common.op)));
+
+    /* We test the generic bp first as it is most likely to be triggered in a
+     * loop. */
+    a.cmp(TMP, imm(op_i_generic_breakpoint));
+    a.b_eq(labels[generic_bp_global]);
+
+    a.cmp(TMP, imm(op_call_bif_W));
+    a.b_eq(call_bif);
+
+    a.cmp(TMP, imm(op_call_error_handler));
+    a.b_eq(error_handler);
+
+    /* Must never happen. */
+    a.udf(0xffff);
+
+    a.bind(call_bif);
+    {
+        /* Emulate a `call_bif` instruction.
+         *
+         * Note that we don't check reductions: yielding here is very tricky
+         * and error-prone, and there's little point in doing so as we can only
+         * land here directly after being scheduled in. */
+        ssize_t func_offset = offsetof(Export, trampoline.bif.address);
+
+        lea(ARG2, arm::Mem(ARG1, offsetof(Export, info.mfa)));
+        a.ldr(ARG3, arm::Mem(c_p, offsetof(Process, i)));
+        a.ldr(ARG4, arm::Mem(ARG1, func_offset));
+
+        /* `call_bif_shared` assumes that the return address has been pushed to
+         * the stack as part of the prologue, so we have to do that manually
+         * now. */
+        emit_enter_erlang_frame();
+        a.b(labels[call_bif_shared]);
+    }
+
+    a.bind(error_handler);
+    {
+        emit_enter_runtime_frame();
+        emit_enter_runtime<Update::eReductions | Update::eHeapAlloc>();
+
+        lea(ARG2, arm::Mem(ARG1, offsetof(Export, info.mfa)));
+        a.mov(ARG1, c_p);
+        load_x_reg_array(ARG3);
+        mov_imm(ARG4, am_undefined_function);
+        runtime_call<4>(call_error_handler);
+
+        /* If there is no error_handler, any number of X registers
+         * can be live. */
+        emit_leave_runtime<Update::eReductions | Update::eHeapAlloc>();
+        emit_leave_runtime_frame();
+
+        a.tst(ARG1, ARG1);
+        a.b_eq(labels[process_exit]);
+
+        branch(emit_setup_dispatchable_call(ARG1));
+    }
 }
 
 /*
@@ -130,8 +188,7 @@ void BeamGlobalAssembler::emit_export_trampoline() {
  * the return address as the error address.
  */
 void BeamModuleAssembler::emit_raise_exception() {
-    // TODO
-    emit_nyi("emit_raise_exception");
+    emit_raise_exception(nullptr);
 }
 
 void BeamModuleAssembler::emit_raise_exception(const ErtsCodeMFA *exp) {

--- a/erts/emulator/beam/jit/arm/32/beam_asm_module.cpp
+++ b/erts/emulator/beam/jit/arm/32/beam_asm_module.cpp
@@ -99,8 +99,61 @@ void BeamModuleAssembler::emit_i_nif_padding() {
 }
 
 void BeamGlobalAssembler::emit_i_breakpoint_trampoline_shared() {
-    // TODO
-    emit_nyi("emit_i_breakpoint_trampoline_shared");
+    constexpr ssize_t flag_offset =
+            sizeof(ErtsCodeInfo) + BEAM_ASM_FUNC_PROLOGUE_SIZE -
+            offsetof(ErtsCodeInfo, u.metadata.breakpoint_flag);
+
+    Label bp_and_nif = a.newLabel(), bp_only = a.newLabel(),
+          nif_only = a.newLabel();
+
+    a.ldrb(ARG1, arm::Mem(a32::lr, -flag_offset));
+
+    a.cmp(ARG1, imm(ERTS_ASM_BP_FLAG_BP_NIF_CALL_NIF_EARLY));
+    a.b_eq(bp_and_nif);
+    ERTS_CT_ASSERT((1 << 0) == ERTS_ASM_BP_FLAG_CALL_NIF_EARLY);
+    a.tst(ARG1, imm(1 << 0));
+    a.b_ne(nif_only);
+    ERTS_CT_ASSERT((1 << 1) == ERTS_ASM_BP_FLAG_BP);
+    a.tst(ARG1, imm(1 << 1));
+    a.b_ne(bp_only);
+
+#ifndef DEBUG
+    a.bx(a32::lr);
+#else
+    Label error = a.newLabel();
+
+    /* ARG1 must be a valid breakpoint flag. */
+    a.tst(ARG1, ARG1);
+    a.b_ne(error);
+    a.bx(a32::lr);
+
+    a.bind(error);
+    a.udf(0xBC0D);
+#endif
+
+    a.bind(bp_and_nif);
+    {
+        emit_enter_runtime_frame();
+        a.bl(labels[generic_bp_local]);
+        emit_leave_runtime_frame();
+
+        /* !! FALL THROUGH !! */
+    }
+
+    a.bind(nif_only);
+    {
+        /* call_nif_early returns on its own, unlike generic_bp_local. */
+        a.b(labels[call_nif_early]);
+    }
+
+    a.bind(bp_only);
+    {
+        emit_enter_runtime_frame();
+        a.bl(labels[generic_bp_local]);
+        emit_leave_runtime_frame();
+
+        a.bx(a32::lr);
+    }
 }
 
 void BeamModuleAssembler::emit_i_breakpoint_trampoline() {

--- a/erts/emulator/beam/jit/arm/32/beam_asm_module.cpp
+++ b/erts/emulator/beam/jit/arm/32/beam_asm_module.cpp
@@ -336,7 +336,7 @@ void BeamModuleAssembler::emit_int_code_end() {
         bind_veneer_target(pair.second);
 
         mov_imm(TMP, pair.first);
-        a.blx(TMP);
+        a.bx(TMP);
     }
 
     mark_unreachable();

--- a/erts/emulator/beam/jit/arm/32/beam_asm_module.cpp
+++ b/erts/emulator/beam/jit/arm/32/beam_asm_module.cpp
@@ -340,6 +340,20 @@ void BeamModuleAssembler::emit_call_error_handler() {
     emit_nyi("call_error_handler should never be called");
 }
 
+const Label &BeamModuleAssembler::resolve_beam_label(const ArgLabel &Lbl,
+                                                     enum Displacement disp) {
+    ASSERT(Lbl.isLabel());
+
+    const Label &beamLabel = rawLabels.at(Lbl.get());
+    const auto &labelEntry = code.labelEntry(beamLabel);
+
+    if (labelEntry->hasName()) {
+        return resolve_label(rawLabels.at(Lbl.get()), disp, labelEntry->name());
+    } else {
+        return resolve_label(rawLabels.at(Lbl.get()), disp);
+    }
+}
+
 const Label &BeamModuleAssembler::resolve_label(const Label &target,
                                                 enum Displacement disp,
                                                 const char *labelName) {

--- a/erts/emulator/beam/jit/arm/32/instr_bif.cpp
+++ b/erts/emulator/beam/jit/arm/32/instr_bif.cpp
@@ -350,33 +350,51 @@ void BeamModuleAssembler::emit_nif_start() {
 }
 
 void BeamGlobalAssembler::emit_bif_nif_epilogue(void) {
-//    Label check_trap = a.newLabel(), trap = a.newLabel(), error = a.newLabel();
-//
-//#ifdef ERTS_MSACC_EXTENDED_STATES
-//    // Skipping msacc profiling for now
-//    emit_nyi("emit_bif_nif_epilogue");
-//#endif
-//
-//    /* Another process may have loaded new code and somehow notified us through
-//     * this call, so we must update the active code index. */
-//    emit_leave_runtime<Update::eStack | Update::eHeap | Update::eXRegs |
-//                       Update::eReductions | Update::eCodeIndex>();
-//
-//    emit_branch_if_not_value(ARG1, check_trap);
-//
-//    comment("Do return and dispatch to it");
-//    a.str(ARG1, getXRef(0));
-//
-//    emit_leave_erlang_frame();
-//
-//    if (erts_alcu_enable_code_atags) {
-//        /* See emit_i_test_yield. */
-//        a.str(a32::lr, arm::Mem(c_p, offsetof(Process, i)));
-//    }
-//
-//    a.bx(a32::lr);
+    Label check_trap = a.newLabel(), trap = a.newLabel(), error = a.newLabel();
 
-    emit_nyi("emit_bif_nif_epilogue");
+#ifdef ERTS_MSACC_EXTENDED_STATES
+    ASSERT(false);
+#endif
+
+    /* Another process may have loaded new code and somehow notified us through
+     * this call, so we must update the active code index. */
+    emit_leave_runtime<Update::eStack | Update::eHeap |
+                       Update::eReductions | Update::eCodeIndex>();
+
+    emit_branch_if_not_value(ARG1, check_trap);
+
+    comment("Do return and dispatch to it");
+    a.str(ARG1, getXRef(0));
+
+    emit_leave_erlang_frame();
+
+    if (erts_alcu_enable_code_atags) {
+        /* See emit_i_test_yield. */
+        a.str(a32::lr, arm::Mem(c_p, offsetof(Process, i)));
+    }
+    
+    a.bx(a32::lr);
+
+    a.bind(check_trap);
+    a.ldr(TMP, arm::Mem(c_p, offsetof(Process, freason)));
+    a.cmp(TMP, imm(TRAP));
+    a.b_ne(error);
+    {
+        comment("yield");
+        emit_nyi("emit_bif_nif_epilogue_yield");
+        
+    }
+
+    a.bind(trap);
+    {
+        comment("do normal trap");
+        emit_nyi("emit_bif_nif_epilogue_normal_trap");
+    }
+
+    a.bind(error);
+    {
+        emit_nyi("emit_bif_nif_epilogue_error");
+    }
 }
 
 /* Used by call_bif, dispatch_bif, and export_trampoline.
@@ -400,7 +418,7 @@ void BeamGlobalAssembler::emit_call_bif_shared(void) {
     a.str(ARG3, arm::Mem(c_p, offsetof(Process, i)));
  
     /* The corresponding leave can be found in the epilogue. */
-    emit_enter_runtime<Update::eStack | Update::eHeap | Update::eXRegs |
+    emit_enter_runtime<Update::eStack | Update::eHeap |
                        Update::eReductions>();
  
  #ifdef ERTS_MSACC_EXTENDED_STATES

--- a/erts/emulator/beam/jit/arm/32/instr_bif.cpp
+++ b/erts/emulator/beam/jit/arm/32/instr_bif.cpp
@@ -394,8 +394,24 @@ void BeamGlobalAssembler::emit_call_bif_shared(void) {
 }
 
 void BeamGlobalAssembler::emit_dispatch_bif(void) {
-    // TODO
-    emit_nyi("emit_dispatch_bif");
+    /* c_p->i points into the trampoline of a ErtsNativeFunc, right after the
+     * `info` structure. */
+    a.ldr(ARG3, arm::Mem(c_p, offsetof(Process, i)));
+    
+    
+    ERTS_CT_ASSERT(offsetof(ErtsNativeFunc, trampoline.call_bif_nif) ==
+                   sizeof(ErtsCodeInfo));
+
+    ssize_t mfa_offset = offsetof(ErtsNativeFunc, trampoline.call_bif_nif) -
+                         offsetof(ErtsNativeFunc, trampoline.info.mfa);
+
+    a.sub(ARG2, ARG3, imm(mfa_offset));
+
+    ssize_t dfunc_offset = offsetof(ErtsNativeFunc, trampoline.dfunc) -
+                           offsetof(ErtsNativeFunc, trampoline.call_bif_nif);
+    a.ldr(ARG4, arm::Mem(ARG3, dfunc_offset));
+
+    a.b(labels[call_bif_shared]);
 }
 
 /* This is only used for opcode compatibility with the interpreter, it's never

--- a/erts/emulator/beam/jit/arm/32/instr_bif.cpp
+++ b/erts/emulator/beam/jit/arm/32/instr_bif.cpp
@@ -483,7 +483,7 @@ void BeamModuleAssembler::emit_call_bif_mfa(const ArgAtom &M,
 
 void BeamGlobalAssembler::emit_call_nif_early() {
     // TODO
-    emit_nyi("emit_call_nif_shared");
+    emit_nyi("emit_call_nif_early");
 }
 
 /* Used by call_nif, call_nif_early, and dispatch_nif.
@@ -494,8 +494,30 @@ void BeamGlobalAssembler::emit_call_nif_early() {
  *
  * ARG3 = current I, just past the end of an ErtsCodeInfo. */
 void BeamGlobalAssembler::emit_call_nif_shared(void) {
-    // TODO
-    emit_nyi("emit_call_nif_shared");
+    /* The corresponding leave can be found in the epilogue. */
+    emit_enter_runtime<Update::eStack | Update::eHeap |
+                       Update::eReductions>();
+
+#ifdef ERTS_MSACC_EXTENDED_STATES
+    {
+        ASSERT(false);
+    }
+#endif
+
+    a.mov(ARG1, c_p);
+    a.mov(ARG2, ARG3);
+    load_x_reg_array(ARG3);
+    ERTS_CT_ASSERT((4 + BEAM_ASM_FUNC_PROLOGUE_SIZE) % sizeof(UWord) == 0);
+    a.ldr(ARG4, arm::Mem(ARG2, 4 + BEAM_ASM_FUNC_PROLOGUE_SIZE));
+    // Loading NifMod as ARG5
+    a.ldr(TMP, arm::Mem(ARG2, 12 + BEAM_ASM_FUNC_PROLOGUE_SIZE));
+    
+    a.sub(a32::sp, a32::sp, imm(8));        // keep AAPCS alignment
+    a.str(TMP, arm::Mem(a32::sp, 0));       // arg5 at [sp]
+    runtime_call<5>(beam_jit_call_nif);
+    a.add(a32::sp, a32::sp, imm(8));
+
+    emit_bif_nif_epilogue();
 }
 
 void BeamGlobalAssembler::emit_dispatch_nif(void) {

--- a/erts/emulator/beam/jit/arm/32/instr_bif.cpp
+++ b/erts/emulator/beam/jit/arm/32/instr_bif.cpp
@@ -252,12 +252,57 @@ void BeamGlobalAssembler::emit_call_light_bif_shared() {
 
         /* ERTS_IS_GC_DESIRED_INTERNAL */
         {
-            emit_nyi("emit_call_light_bif_ERTS_IS_GC_DESIRED_INTERNAL");
+            Label check_fragments = a.newLabel();
+
+            /* Test whether GC is forced. */
+            a.ldr(TMP, arm::Mem(c_p, offsetof(Process, flags)));
+            a.tst(TMP, imm(F_FORCE_GC | F_DISABLE_GC));
+            a.b_ne(gc_after_bif_call);
+
+            /* Test if binary heap size should trigger GC. */
+            a.ldr(TMP, arm::Mem(c_p, offsetof(Process, bin_vheap_sz)));
+            a.ldr(VAR, arm::Mem(c_p, offsetof(Process, off_heap.overhead)));
+            a.cmp(VAR, TMP);
+            a.b_ls(check_fragments);
+            a.b(gc_after_bif_call);
+
+            /* Test if heap fragment size is larger than remaining heap size. */
+            a.bind(check_fragments);
+            a.sub(TMP, E, HTOP);
+            a.ldr(VAR, arm::Mem(c_p, offsetof(Process, mbuf_sz)));
+            a.lsl(VAR, VAR, imm(3));
+            a.cmp(TMP, VAR);
+            a.b_lo(gc_after_bif_call);
         }
 
         a.bind(check_bif_return);
         {
-          emit_nyi("emit_call_light_bif_check_bif_return");
+            Label trap = a.newLabel(), error = a.newLabel();
+
+            emit_branch_if_not_value(ARG1, trap);
+
+            a.str(ARG1, getXRef(0));
+            a.bx(a32::lr);
+
+            a.bind(trap);
+            {
+                a.ldr(TMP, arm::Mem(c_p, offsetof(Process, freason)));
+                a.cmp(TMP, imm(TRAP));
+                a.b_ne(error);
+
+                /* Trap out, preserving our continuation on the Erlang stack. */
+                emit_enter_erlang_frame();
+                a.ldr(ARG3, arm::Mem(c_p, offsetof(Process, i)));
+                a.b(labels[context_switch_simplified]);
+            }
+
+            a.bind(error);
+            {
+                a.ldr(ARG2, entry_mem);
+                a.ldr(ARG4, export_mem);
+                add(ARG4, ARG4, offsetof(Export, info.mfa));
+                a.b(labels[raise_exception_shared]);
+            }
         }
 
         a.bind(gc_after_bif_call);

--- a/erts/emulator/beam/jit/arm/32/instr_bif.cpp
+++ b/erts/emulator/beam/jit/arm/32/instr_bif.cpp
@@ -414,7 +414,7 @@ void BeamGlobalAssembler::emit_call_bif_shared(void) {
     a.str(ARG2, arm::Mem(c_p, offsetof(Process, current)));
 
     a.ldr(TMP, arm::Mem(ARG2, offsetof(ErtsCodeMFA, arity)));
-    a.str(TMP, arm::Mem(c_p, offsetof(Process, arity)));
+    a.strb(TMP, arm::Mem(c_p, offsetof(Process, arity)));
     a.str(ARG3, arm::Mem(c_p, offsetof(Process, i)));
  
     /* The corresponding leave can be found in the epilogue. */

--- a/erts/emulator/beam/jit/arm/32/instr_bif.cpp
+++ b/erts/emulator/beam/jit/arm/32/instr_bif.cpp
@@ -389,8 +389,43 @@ void BeamGlobalAssembler::emit_bif_nif_epilogue(void) {
  * ARG3 = I (rip), doesn't need to point past an MFA
  * ARG4 = function to be called */
 void BeamGlobalAssembler::emit_call_bif_shared(void) {
-    // TODO
-    emit_nyi("emit_call_bif_shared");
+    /* "Heavy" BIFs need up-to-date values for `c_p->i`, `c_p->current`, and
+     * `c_p->arity`. */
+
+    emit_enter_runtime_frame();
+    a.str(ARG2, arm::Mem(c_p, offsetof(Process, current)));
+
+    a.ldr(TMP, arm::Mem(ARG2, offsetof(ErtsCodeMFA, arity)));
+    a.str(TMP, arm::Mem(c_p, offsetof(Process, arity)));
+    a.str(ARG3, arm::Mem(c_p, offsetof(Process, i)));
+ 
+    /* The corresponding leave can be found in the epilogue. */
+    emit_enter_runtime<Update::eStack | Update::eHeap | Update::eXRegs |
+                       Update::eReductions>();
+ 
+ #ifdef ERTS_MSACC_EXTENDED_STATES
+    {
+        ASSERT(false);
+    }
+ #endif
+ 
+    a.mov(ARG1, c_p);
+    load_x_reg_array(ARG2);
+    /* ARG3 (I), ARG4 (func) have already been provided.
+     * `call_bif` wants arity as fifth argument. 
+     * This requires us to allocate it on the stack.
+     */
+    a.sub(a32::sp, a32::sp, imm(8)); // keep 8-byte alignment
+    a.str(TMP, arm::Mem(a32::sp, 0)); // store arity on the stack
+    runtime_call<5>(beam_jit_call_bif);
+    a.add(a32::sp, a32::sp, imm(8)); // delete arity from the stack
+ 
+ #ifdef ERTS_MSACC_EXTENDED_STATES
+    ASSERT(false); 
+ #endif
+ 
+    emit_leave_runtime_frame();
+    emit_bif_nif_epilogue();
 }
 
 void BeamGlobalAssembler::emit_dispatch_bif(void) {

--- a/erts/emulator/beam/jit/arm/32/instr_call.cpp
+++ b/erts/emulator/beam/jit/arm/32/instr_call.cpp
@@ -46,8 +46,7 @@ void BeamModuleAssembler::emit_move_deallocate_return() {
 }
 
 void BeamModuleAssembler::emit_i_call(const ArgLabel &CallTarget) {
-    // TODO
-    emit_nyi("emit_i_call");
+    erlang_call(resolve_beam_label(CallTarget, disp32MB));
 }
 
 void BeamModuleAssembler::emit_i_call_last(const ArgLabel &CallTarget,
@@ -85,8 +84,12 @@ void BeamModuleAssembler::emit_i_call_ext(const ArgExport &Exp) {
 }
 
 void BeamModuleAssembler::emit_i_call_ext_only(const ArgExport &Exp) {
-    // TODO
-    emit_nyi("emit_i_call_ext_only");
+    mov_arg(ARG1, Exp);
+
+    arm::Mem target = emit_setup_dispatchable_call(ARG1);
+    emit_leave_erlang_frame();
+    branch(target);
+    mark_unreachable();
 }
 
 void BeamModuleAssembler::emit_i_call_ext_last(const ArgExport &Exp,

--- a/erts/emulator/beam/jit/arm/32/instr_call.cpp
+++ b/erts/emulator/beam/jit/arm/32/instr_call.cpp
@@ -26,18 +26,38 @@ extern "C"
 }
 
 void BeamGlobalAssembler::emit_dispatch_return() {
-    // TODO
-    emit_nyi("emit_dispatch_return");
+    a.mov(ARG3, a32::lr);
+    mov_imm(TMP, 0);
+    a.str(TMP, arm::Mem(c_p, offsetof(Process, current)));
+    mov_imm(TMP, 1);
+    a.strb(TMP, arm::Mem(c_p, offsetof(Process, arity)));
+    a.b(labels[context_switch_simplified]);
 }
 
 void BeamModuleAssembler::emit_dispatch_return() {
-    // TODO
-    emit_nyi("emit_dispatch_return");
+#ifdef JIT_HARD_DEBUG
+    /* Validate return address and {x,0} */
+    emit_validate(ArgWord(1));
+#endif
+
+    if (erts_alcu_enable_code_atags) {
+        /* See emit_i_test_yield. */
+        a.str(a32::lr, arm::Mem(c_p, offsetof(Process, i)));
+    }
+
+    /* The reduction test is kept in module code because moving it to a shared
+     * fragment caused major performance regressions in dialyzer. */
+    a.subs(FCALLS, FCALLS, imm(1));
+    a.b_le(resolve_fragment(ga->get_dispatch_return(), disp32MB));
+
+    a.bx(a32::lr);
+
+    mark_unreachable();
 }
 
 void BeamModuleAssembler::emit_return() {
-    // TODO
-    emit_nyi("emit_return");
+    emit_leave_erlang_frame();
+    emit_dispatch_return();
 }
 
 void BeamModuleAssembler::emit_move_deallocate_return() {

--- a/erts/emulator/beam/jit/arm/32/instr_call.cpp
+++ b/erts/emulator/beam/jit/arm/32/instr_call.cpp
@@ -64,8 +64,9 @@ void BeamModuleAssembler::emit_move_call_last(const ArgYRegister &Src,
 }
 
 void BeamModuleAssembler::emit_i_call_only(const ArgLabel &CallTarget) {
-    // TODO
-    emit_nyi("emit_i_call_only");
+    emit_leave_erlang_frame();
+    a.b(resolve_beam_label(CallTarget, disp32MB));
+    mark_unreachable();
 }
 
 /* Handles save_calls for remote calls. When the active code index is

--- a/erts/emulator/beam/jit/arm/32/instr_call.cpp
+++ b/erts/emulator/beam/jit/arm/32/instr_call.cpp
@@ -115,8 +115,8 @@ void BeamModuleAssembler::emit_i_call_ext_only(const ArgExport &Exp) {
 
 void BeamModuleAssembler::emit_i_call_ext_last(const ArgExport &Exp,
                                                const ArgWord &Deallocate) {
-    // TODO
-    emit_nyi("emit_i_call_ext_last");
+    emit_deallocate(Deallocate);
+    emit_i_call_ext_only(Exp);
 }
 
 void BeamModuleAssembler::emit_move_call_ext_last(const ArgYRegister &Src,

--- a/erts/emulator/beam/jit/arm/32/instr_common.cpp
+++ b/erts/emulator/beam/jit/arm/32/instr_common.cpp
@@ -162,8 +162,11 @@ void BeamModuleAssembler::emit_allocate(const ArgWord &NeedStack,
 }
 
 void BeamModuleAssembler::emit_deallocate(const ArgWord &Deallocate) {
-    // TODO
-    emit_nyi("emit_deallocate");
+    ASSERT(Deallocate.get() <= 1023);
+
+    if (Deallocate.get() > 0) {
+        add(E, E, Deallocate.get() * sizeof(Eterm));
+    }
 }
 
 void BeamModuleAssembler::emit_test_heap(const ArgWord &Nh,

--- a/erts/emulator/beam/jit/arm/32/instr_common.cpp
+++ b/erts/emulator/beam/jit/arm/32/instr_common.cpp
@@ -745,8 +745,11 @@ void BeamModuleAssembler::emit_badrecord(const ArgSource &Src) {
 
 void BeamModuleAssembler::emit_catch(const ArgYRegister &Y,
                                      const ArgCatch &Handler) {
-    // TODO
-    emit_nyi("emit_catch");
+    a.ldr(TMP, arm::Mem(c_p, offsetof(Process, catches)));
+    a.add(TMP, TMP, imm(1));
+    a.str(TMP, arm::Mem(c_p, offsetof(Process, catches)));
+
+    mov_arg(Y, Handler);
 }
 
 void BeamGlobalAssembler::emit_catch_end_shared() {

--- a/erts/emulator/beam/jit/arm/32/instr_common.cpp
+++ b/erts/emulator/beam/jit/arm/32/instr_common.cpp
@@ -768,8 +768,12 @@ void BeamModuleAssembler::emit_try_end(const ArgYRegister &CatchTag) {
 }
 
 void BeamModuleAssembler::emit_try_end_deallocate(const ArgWord &Deallocate) {
-    // TODO
-    emit_nyi("emit_try_end_deallocate");
+    a.ldr(TMP, arm::Mem(c_p, offsetof(Process, catches)));
+    a.sub(TMP, TMP, imm(1));
+    a.str(TMP, arm::Mem(c_p, offsetof(Process, catches)));
+    if (Deallocate.get() > 0) {
+        add(E, E, Deallocate.get() * sizeof(Eterm));
+    }
 }
 
 void BeamModuleAssembler::emit_try_end_move_deallocate(

--- a/erts/emulator/beam/jit/arm/32/instr_common.cpp
+++ b/erts/emulator/beam/jit/arm/32/instr_common.cpp
@@ -97,8 +97,43 @@ void BeamModuleAssembler::emit_gc_test(const ArgWord &Ns,
 }
 
 void BeamModuleAssembler::emit_validate(const ArgWord &Arity) {
-    // TODO
-    emit_nyi("emit_validate");
+#ifdef DEBUG
+    Label next = a.newLabel(), crash = a.newLabel();
+
+    /* Crash if the Erlang heap is not word-aligned */
+    a.tst(HTOP, imm(sizeof(Eterm) - 1));
+    a.b_ne(crash);
+
+    /* Crash if the Erlang stack is not word-aligned */
+    a.tst(E, imm(sizeof(Eterm) - 1));
+    a.b_ne(crash);
+
+    /* Crash if we've overrun the stack */
+    lea(TMP, arm::Mem(E, -(int32_t)(S_REDZONE * sizeof(Eterm))));
+    a.cmp(HTOP, TMP);
+    a.b_hi(crash);
+
+    a.b(next);
+
+    a.bind(crash);
+    a.udf(0xbad);
+    a.bind(next);
+
+#    ifdef JIT_HARD_DEBUG
+    emit_enter_runtime_frame();
+
+    for (unsigned i = 0; i < Arity.get(); i++) {
+        mov_arg(ARG1, ArgVal(ArgVal::XReg, i));
+
+        emit_enter_runtime();
+        runtime_call<1>(beam_jit_validate_term);
+        emit_leave_runtime();
+    }
+
+    emit_leave_runtime_frame();
+#    endif
+
+#endif
 }
 
 /* Instrs */

--- a/erts/emulator/beam/jit/arm/32/process_main.cpp
+++ b/erts/emulator/beam/jit/arm/32/process_main.cpp
@@ -54,6 +54,17 @@ void BeamGlobalAssembler::emit_process_main() {
     /* Be kind to debuggers and `perf` by setting up a proper stack frame. */
     emit_enter_runtime_frame();
 
+    /* Normal schedulers don't get a preallocated register block; keep it on
+     * the runtime stack like other JIT backends do. */
+    sub(a32::sp,
+        a32::sp,
+        sizeof(ErtsSchedulerRegisters) + ERTS_CACHE_LINE_SIZE);
+    mov_imm(TMP, ~ERTS_CACHE_LINE_MASK);
+    a.and_(a32::sp, a32::sp, TMP);
+
+    a.str(a32::sp, arm::Mem(ARG1, offsetof(ErtsSchedulerData, registers)));
+    a.mov(scheduler_registers, a32::sp);
+
     /* The offset of start_time_i in ErtsSchedulerRegisters cannot stay
      * in the 12 bit immediate accepted by the STR instruction.
      *

--- a/erts/emulator/beam/jit/arm/32/process_main.cpp
+++ b/erts/emulator/beam/jit/arm/32/process_main.cpp
@@ -66,19 +66,38 @@ void BeamGlobalAssembler::emit_process_main() {
     a.mov(scheduler_registers, a32::sp);
 
     /* The offset of start_time_i in ErtsSchedulerRegisters cannot stay
-     * in the 12 bit immediate accepted by the STR instruction.
-     *
-     * We use ARG4 to point to start_time_i so then we can use a relative offset
-     * to point to start_time.
-     */
+     * in the 12-bit immediate accepted by STR/LDR. */
     const Uint start_t_i_offset = offsetof(ErtsSchedulerRegisters, start_time_i);
     const Uint start_t_offset = offsetof(ErtsSchedulerRegisters, start_time);
     // start_time precedes start_time_i in the struct
     const Uint relative_start_t_offset = start_t_offset - start_t_i_offset;
-    a.mov(ARG4, scheduler_registers);
-    a.add(ARG4, ARG4, imm(start_t_i_offset));
+    /*
+     * We use ARG4 as Base register for the memory operand. 
+     * This means we have to setup ARG4,
+     * each time we need to read or write start_time_i or start_time.
+    */
     const arm::Mem start_time_i = arm::Mem(ARG4);
     const arm::Mem start_time = arm::Mem(ARG4, relative_start_t_offset);
+    auto setup_start_time_base = [&]() {
+        a.mov(ARG4, scheduler_registers);
+        a.add(ARG4, ARG4, imm(start_t_i_offset));
+    };
+    auto load_start_time = [&](const a32::Gp &dst) {
+        setup_start_time_base();
+        a.ldr(dst, start_time);
+    };
+    auto load_start_time_i = [&](const a32::Gp &dst) {
+        setup_start_time_base();
+        a.ldr(dst, start_time_i);
+    };
+    auto store_start_time = [&](const a32::Gp &src) {
+        setup_start_time_base();
+        a.str(src, start_time);
+    };
+    auto store_start_time_i = [&](const a32::Gp &src) {
+        setup_start_time_base();
+        a.str(src, start_time_i);
+    };
 
     /* Save the initial SP of the thread so that we can verify that it
      * doesn't grow. */
@@ -91,8 +110,8 @@ void BeamGlobalAssembler::emit_process_main() {
 
     // Scheduling loop initialization
     mov_imm(TMP, 0);
-    a.str(TMP, start_time_i);
-    a.str(TMP, start_time);
+    store_start_time_i(TMP);
+    store_start_time(TMP);
 
     mov_imm(c_p, 0);
     mov_imm(FCALLS, 0);
@@ -110,11 +129,18 @@ void BeamGlobalAssembler::emit_process_main() {
         a.sub(ARG3, TMP, FCALLS);
         a.b(schedule_next);
     }
-
+    
+    /*
+     * The *next* instruction pointer is provided in ARG3, and must be preceded
+     * by an ErtsCodeMFA.
+     */
     a.bind(context_switch_local);
     comment("Context switch, unknown arity/MFA");
-    //TODO
-    emit_nyi("context_switch_local");
+    {
+        emit_nyi("context_switch_local unknown arity/MFA");        
+        /* !! Fall through !! */
+    }
+
     a.bind(context_switch_simplified_local);
     comment("Context switch, known arity and MFA");
     {
@@ -171,23 +197,23 @@ void BeamGlobalAssembler::emit_process_main() {
         /* ARG3 contains reds_used at this point */
 
         //Jump to schedule if start_time is 0
-        a.ldr(TMP, start_time);
+        load_start_time(TMP);
         a.tst(TMP, TMP);
         a.b_eq(schedule);
         // Call check_monitor_long_schedule, a performance monitoring function
         // that detects when Erlang processes run for too long without yielding.
         {
             a.mov(ARG1, c_p);
-            a.ldr(ARG2, start_time);
+            load_start_time(ARG2);
 
             /* Spill reds_used in start_time slot */
-            a.str(ARG3, start_time);
+            store_start_time(ARG3);
 
-            a.ldr(ARG3, start_time_i);
+            load_start_time_i(ARG3);
             runtime_call<3>(check_monitor_long_schedule);
 
             /* Restore reds_used */
-            a.ldr(ARG3, start_time);
+            load_start_time(ARG3);
         }
 
         a.bind(schedule);
@@ -206,7 +232,7 @@ void BeamGlobalAssembler::emit_process_main() {
 #endif
 
         mov_imm(TMP, 0);
-        a.str(TMP, start_time);
+        store_start_time(TMP);
         mov_imm(ARG1, &erts_system_monitor_long_schedule);
         a.ldr(TMP, arm::Mem(ARG1));
         a.tst(TMP, TMP);
@@ -215,9 +241,9 @@ void BeamGlobalAssembler::emit_process_main() {
         {
             /* Enable long schedule test */
             runtime_call<0>(erts_timestamp_millis);
-            a.str(ARG1, start_time);
+            store_start_time(ARG1);
             a.ldr(TMP, arm::Mem(c_p, offsetof(Process, i)));
-            a.str(TMP, start_time_i);
+            store_start_time_i(TMP);
         }
 
         a.bind(skip_long_schedule);

--- a/erts/emulator/beam/jit/beam_jit_args.hpp
+++ b/erts/emulator/beam/jit/beam_jit_args.hpp
@@ -120,7 +120,12 @@ struct ArgVal : public BeamOpArg {
 
     struct Hash {
         constexpr size_t operator()(const ArgVal &key) const {
+#ifdef ARCH_32
+            /* TYPE fits in 8 bits; put in high byte to mimic 64-bit */
+            return ((size_t)key.getType() << 24) ^ (size_t)key.val;
+#else
             return ((size_t)key.getType() << 48) ^ (size_t)key.val;
+#endif
         }
     };
 

--- a/erts/preloaded/src/hello.erl
+++ b/erts/preloaded/src/hello.erl
@@ -71,12 +71,12 @@
 %%%
 %%%    res = erl_spawn_system_process(&parent, am_hello, am_start, args, &so);
 %%%
-start(_BootMod, _BootArgs) ->
-    %hello(BootArgs),
+start(_BootMod, BootArgs) ->
+    hello(BootArgs),
     halt(42, [{flush, false}]).
 %
 %%% Entry from test suite.
-%hello(BootArgs) ->
+hello(_BootArgs) ->
 %    _ = id(BootArgs),
 %    erlang:display_string("hello, world\n"),
 %    erlang:display_string(id("arguments: ")),
@@ -84,7 +84,7 @@ start(_BootMod, _BootArgs) ->
 %
 %    erlang:display_string("Testing stuff (should not crash)...\n"),
 %    test(BootArgs),
-%    erlang:display_string("Everything is fine!\n"),
+    erlang:display_string("Everything is fine!\n").
 %
 %    estone().
 %

--- a/erts/preloaded/src/hello.erl
+++ b/erts/preloaded/src/hello.erl
@@ -73,7 +73,7 @@
 %%%
 start(_BootMod, BootArgs) ->
     hello(BootArgs),
-    halt(42, [{flush, false}]).
+    halt(42).
 %
 %%% Entry from test suite.
 hello(_BootArgs) ->
@@ -84,7 +84,7 @@ hello(_BootArgs) ->
 %
 %    erlang:display_string("Testing stuff (should not crash)...\n"),
 %    test(BootArgs),
-    erlang:display_string("Everything is fine!\n").
+     erlang:display_string("Everything is fine!\n").
 %
 %    estone().
 %


### PR DESCRIPTION
The aim of this PR is to be able to load the `erlang` module and execute its `display_string` NIF.