### PR TITLE
Disable debugger build in custom configuration

### DIFF
--- a/xcomp/erl-xcomp-arm-linux-debug-custom.conf
+++ b/xcomp/erl-xcomp-arm-linux-debug-custom.conf
@@ -34,7 +34,7 @@
 ## variables needs to be defined as arguments to `configure' or exported in
 ## the environment.
 JIT="--enable-jit"
-DISABLED_APPS="--without-dialyzer --without-et --without-hipe --without-javac --without-jinterface --without-megaco --without-observer --without-odbc --without-os_mon --without-typer --without-wx"
+DISABLED_APPS="--without-dialyzer --without-et --without-hipe --without-javac --without-jinterface --without-megaco --without-debugger --without-observer --without-odbc --without-os_mon --without-typer --without-wx"
 CRYPTO_CONFIG_OPTION=""
 
 ## -- Variables for `otp_build' Only -------------------------------------------

--- a/xcomp/erl-xcomp-arm-linux-release-custom.conf
+++ b/xcomp/erl-xcomp-arm-linux-release-custom.conf
@@ -34,7 +34,7 @@
 ## variables needs to be defined as arguments to `configure' or exported in
 ## the environment.
 JIT="--enable-jit"
-DISABLED_APPS="--without-dialyzer --without-et --without-hipe --without-javac --without-jinterface --without-megaco --without-observer --without-odbc --without-typer --without-wx"
+DISABLED_APPS="--without-dialyzer --without-et --without-hipe --without-javac --without-jinterface --without-megaco --without-debugger --without-observer --without-odbc --without-typer --without-wx"
 CRYPTO_CONFIG_OPTION=""
 
 ## -- Variables for `otp_build' Only -------------------------------------------


### PR DESCRIPTION
This fixes compilation errors due to a wx dependency in debugger.