### PR TITLE
Recognize plain arm host_cpu for ARM32 JIT

### DIFF
--- a/make/autoconf/otp.m4
+++ b/make/autoconf/otp.m4
@@ -2964,6 +2964,7 @@ AC_DEFUN([LM_HARDWARE_ARCH], [
     powerpc64)	ARCH=ppc64;;
     powerpc64le) ARCH=ppc64le;;
     "Power Macintosh")	ARCH=ppc;;
+    arm)	ARCH=arm;;
     arm64)	ARCH=arm64;;
     armv5b)	ARCH=arm;;
     armv5teb)	ARCH=arm;;


### PR DESCRIPTION
Buildroot configures OTP with `--host=arm-buildroot-linux-gnueabihf`, which sets `host_cpu` to `arm`. This results in a plain `arm` that ends up causing cross builds to not pass the ARM32 JIT check.